### PR TITLE
feat: add explicit key + scf_keys, rename files, split version from name

### DIFF
--- a/framework.schema.json
+++ b/framework.schema.json
@@ -4,6 +4,7 @@
   "title": "episki Framework Definition (Unified Controls + Recursive Tests)",
   "type": "object",
   "required": [
+    "key",
     "name",
     "short_name",
     "last_updated",
@@ -13,6 +14,22 @@
     "controls"
   ],
   "properties": {
+    "key": {
+      "description": "Stable slug identifier for the framework. Lowercase, hyphen-separated. Hand-set to match SCF's slug where the framework exists in SCF; arbitrary otherwise. This is what eload writes to catalog.frameworks.key.",
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 1
+    },
+    "scf_keys": {
+      "description": "SCF framework keys that should alias to this framework. When eload loads SCF crosswalks, mapping refs to any of these SCF keys are attached to this framework instead of creating duplicate SCF-only stub rows.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
     "name": { "type": "string", "minLength": 1 },
     "short_name": { "type": "string", "minLength": 1 },
 

--- a/frameworks/aicpa-tsc-soc-2.json
+++ b/frameworks/aicpa-tsc-soc-2.json
@@ -1,6 +1,13 @@
 {
-  "name": "SOC2 Trust Service Criteria",
-  "short_name": "SOC2 Trust Service Criteria",
+  "key": "aicpa-tsc-soc-2",
+  "name": "AICPA Trust Services Criteria (SOC 2)",
+  "short_name": "AICPA TSC",
+  "version": "2017:2022",
+  "publisher": "AICPA",
+  "source_url": "https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2",
+  "scf_keys": [
+    "aicpa-tsc-2017-2022-used-for-soc-2"
+  ],
   "last_updated": "2025-07-17",
   "description": "AICPA trust service criteria for evaluating controls related to security, availability, processing integrity, confidentiality, and privacy.",
   "category": "framework",

--- a/frameworks/cis-csc-8-1.json
+++ b/frameworks/cis-csc-8-1.json
@@ -1,6 +1,16 @@
 {
+  "key": "cis-csc-8-1",
   "name": "CIS Critical Security Controls",
-  "short_name": "CIS Critical Security Controls",
+  "short_name": "CIS CSC",
+  "version": "8.1",
+  "publisher": "Center for Internet Security",
+  "source_url": "https://www.cisecurity.org/controls",
+  "scf_keys": [
+    "cis-csc-8-1",
+    "cis-csc-8-1-ig1",
+    "cis-csc-8-1-ig2",
+    "cis-csc-8-1-ig3"
+  ],
   "last_updated": "2026-01-14",
   "description": "Prioritized cybersecurity best practices to defend against common attacks.",
   "category": "framework",

--- a/frameworks/csa-ai-control-matrix.json
+++ b/frameworks/csa-ai-control-matrix.json
@@ -1,6 +1,9 @@
 {
+  "key": "csa-ai-control-matrix",
   "name": "CSA AI Control Matrix",
-  "short_name": "CSA AI Control Matrix",
+  "short_name": "CSA AICM",
+  "publisher": "Cloud Security Alliance",
+  "source_url": "https://cloudsecurityalliance.org/research/working-groups/ai-controls/",
   "last_updated": "2025-10-20",
   "description": "Vendor-agnostic security controls for cloud-based AI systems, covering 243 objectives across 18 domains.",
   "category": "framework",

--- a/frameworks/emea-eu-gdpr.json
+++ b/frameworks/emea-eu-gdpr.json
@@ -1,6 +1,12 @@
 {
+  "key": "emea-eu-gdpr",
   "name": "GDPR",
   "short_name": "GDPR",
+  "publisher": "European Union",
+  "source_url": "https://eur-lex.europa.eu/eli/reg/2016/679/oj",
+  "scf_keys": [
+    "emea-eu-gdpr"
+  ],
   "last_updated": "2025-07-18",
   "description": "European Union regulation on data protection and privacy for individuals within the EU and EEA.",
   "category": "framework",

--- a/frameworks/emea-uk-cyber-essentials.json
+++ b/frameworks/emea-uk-cyber-essentials.json
@@ -1,6 +1,13 @@
 {
-  "name": "Cyber Essentials UK v3.2",
-  "short_name": "Cyber Essentials UK v3.2",
+  "key": "emea-uk-cyber-essentials",
+  "name": "Cyber Essentials UK",
+  "short_name": "Cyber Essentials UK",
+  "version": "3.2",
+  "publisher": "UK National Cyber Security Centre",
+  "source_url": "https://www.ncsc.gov.uk/cyberessentials/",
+  "scf_keys": [
+    "emea-uk-cyber-essentials"
+  ],
   "last_updated": "2025-04-01",
   "description": "UK government-backed certification scheme for protecting against common cyber threats through basic security controls.",
   "category": "framework",

--- a/frameworks/iso-27001-2022.json
+++ b/frameworks/iso-27001-2022.json
@@ -1,6 +1,13 @@
 {
-  "name": "ISO 27001",
+  "key": "iso-27001-2022",
+  "name": "ISO/IEC 27001",
   "short_name": "ISO 27001",
+  "version": "2022",
+  "publisher": "International Organization for Standardization",
+  "source_url": "https://www.iso.org/standard/27001",
+  "scf_keys": [
+    "iso-27001-2022"
+  ],
   "last_updated": "2025-06-02",
   "description": "International standard for establishing, implementing, and maintaining an information security management system (ISMS).",
   "category": "framework",

--- a/frameworks/iso-27002-2022.json
+++ b/frameworks/iso-27002-2022.json
@@ -1,6 +1,13 @@
 {
-  "name": "ISO 27002",
+  "key": "iso-27002-2022",
+  "name": "ISO/IEC 27002",
   "short_name": "ISO 27002",
+  "version": "2022",
+  "publisher": "International Organization for Standardization",
+  "source_url": "https://www.iso.org/standard/75652.html",
+  "scf_keys": [
+    "iso-27002-2022"
+  ],
   "last_updated": "2025-07-18",
   "description": "Reference set of information security controls and implementation guidance for ISO 27001.",
   "category": "framework",

--- a/frameworks/nist-ai-100-1-ai-rmf.json
+++ b/frameworks/nist-ai-100-1-ai-rmf.json
@@ -1,6 +1,13 @@
 {
+  "key": "nist-ai-100-1-ai-rmf",
   "name": "NIST AI Risk Management Framework",
-  "short_name": "NIST AI Risk Management Framework",
+  "short_name": "NIST AI RMF",
+  "version": "1.0",
+  "publisher": "National Institute of Standards and Technology",
+  "source_url": "https://www.nist.gov/itl/ai-risk-management-framework",
+  "scf_keys": [
+    "nist-ai-100-1-ai-rmf-1-0"
+  ],
   "last_updated": "2025-11-18",
   "description": "Framework for managing risks throughout the AI system lifecycle.",
   "category": "framework",

--- a/frameworks/nist-csf-2-0.json
+++ b/frameworks/nist-csf-2-0.json
@@ -1,6 +1,13 @@
 {
-  "name": "NIST CSF 2.0",
-  "short_name": "NIST CSF 2.0",
+  "key": "nist-csf-2-0",
+  "name": "NIST Cybersecurity Framework",
+  "short_name": "NIST CSF",
+  "version": "2.0",
+  "publisher": "National Institute of Standards and Technology",
+  "source_url": "https://www.nist.gov/cyberframework",
+  "scf_keys": [
+    "nist-csf-2-0"
+  ],
   "last_updated": "2026-01-22",
   "description": "Voluntary framework for managing cybersecurity risk across identify, protect, detect, respond, and recover functions.",
   "category": "framework",

--- a/frameworks/nist-sp-800-66-r2.json
+++ b/frameworks/nist-sp-800-66-r2.json
@@ -1,6 +1,13 @@
 {
-  "name": "NIST 800-66 r2",
-  "short_name": "NIST 800-66 r2",
+  "key": "nist-sp-800-66-r2",
+  "name": "NIST SP 800-66",
+  "short_name": "NIST 800-66",
+  "version": "r2",
+  "publisher": "National Institute of Standards and Technology",
+  "source_url": "https://csrc.nist.gov/pubs/sp/800/66/r2/final",
+  "scf_keys": [
+    "nist-sp-800-66-r2"
+  ],
   "last_updated": "2025-05-07",
   "description": "NIST guidance for implementing the HIPAA Security Rule through recognized cybersecurity practices.",
   "category": "framework",

--- a/frameworks/owasp-dsomm.json
+++ b/frameworks/owasp-dsomm.json
@@ -1,6 +1,9 @@
 {
-  "name": "OWASP DevSecOps Maturity Model (DSOMM)",
+  "key": "owasp-dsomm",
+  "name": "OWASP DevSecOps Maturity Model",
   "short_name": "DSOMM",
+  "publisher": "OWASP",
+  "source_url": "https://owasp.org/www-project-devsecops-maturity-model/",
   "last_updated": "2026-03-17",
   "description": "The OWASP DevSecOps Maturity Model (DSOMM) provides a framework for integrating security into DevOps practices across five dimensions: Build and Deployment, Culture and Organization, Implementation, Information Gathering, and Test and Verification. Activities are organized into maturity levels 1 through 5.",
   "category": "framework",

--- a/frameworks/owasp-samm.json
+++ b/frameworks/owasp-samm.json
@@ -1,5 +1,6 @@
 {
-  "name": "OWASP Software Assurance Maturity Model (SAMM)",
+  "key": "owasp-samm",
+  "name": "OWASP Software Assurance Maturity Model",
   "short_name": "SAMM",
   "version": "2.0",
   "publisher": "OWASP",
@@ -44,19 +45,25 @@
                   "ref": "G-SM-1-A",
                   "label": "Identify the organization's risk appetite",
                   "description": "[Maturity Level 1] Identify organization drivers as they relate to the organization's risk tolerance. Understand, based on application risk exposure, what threats exist or may exist, as well as how tolerant executive leadership is of these risks. This understanding is a key component of determining software security assurance priorities. To ascertain these threats, interview business owners and stakeholders and document drivers specific to industries where the organization operates as well as drivers specific to the organization.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "G-SM-2-A",
                   "label": "Define the security strategy",
                   "description": "[Maturity Level 2] Publish a unified strategy for application security. Based on the magnitude of assets, threats, and risk tolerance, develop a security strategic plan and budget to address your security needs. The plan covers 1 to 3 years and includes milestones consistent with your risk profile, the organization's business drivers, and the existing technical debt.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "G-SM-3-A",
                   "label": "Align security and business strategies",
                   "description": "[Maturity Level 3] Align the application security program to support the organization's growth. Review the application security plan annually with executive management, and receive endorsement and resource allocation. Ensure the plan reflects the organization's evolving business strategy and risk tolerance, including support of new technologies or business processes.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -70,19 +77,25 @@
                   "ref": "G-SM-1-B",
                   "label": "Define basic security metrics",
                   "description": "[Maturity Level 1] Define metrics with insight into the effectiveness and efficiency of the application security program. Identify objectives and means of measuring effectiveness of the security program. Capture both quantitative and qualitative metrics and review them regularly.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "G-SM-2-B",
                   "label": "Set strategic KPIs",
                   "description": "[Maturity Level 2] Set targets and KPIs for measuring the program effectiveness. Define Key Performance Indicators (KPIs) to help focus and measure program effectiveness in supporting the organization's business objectives.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "G-SM-3-B",
                   "label": "Drive the security program through metrics",
                   "description": "[Maturity Level 3] Influence the strategy based on the metrics and organizational needs. Define guidelines for the influencing the application security program based on the defined metrics. Review metrics on a regular basis with responsible management and adjust the program where metrics indicate it is not performing as expected.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -104,19 +117,25 @@
                   "ref": "G-PC-1-A",
                   "label": "Define policies and standards",
                   "description": "[Maturity Level 1] Determine a security baseline representing organization's policies and standards. Develop a set of application security policies and standards aligned with the organization's overall security strategy and compliance requirements.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "G-PC-2-A",
                   "label": "Develop test procedures",
                   "description": "[Maturity Level 2] Develop security requirements applicable to all applications. Create standardized test procedures to verify compliance with security policies and standards, making them available across development teams.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "G-PC-3-A",
                   "label": "Measure compliance to policies and standards",
                   "description": "[Maturity Level 3] Measure and report on the status of individual application's adherence to policies and standards. Continuously monitor and measure compliance across the organization, using automated tools where possible.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -130,19 +149,25 @@
                   "ref": "G-PC-1-B",
                   "label": "Identify compliance requirements",
                   "description": "[Maturity Level 1] Identify 3rd-party compliance drivers and requirements and map to existing policies and standards. Understand applicable regulatory and compliance requirements and map them to your organization's security policies.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "G-PC-2-B",
                   "label": "Standardize policy and compliance requirements",
                   "description": "[Maturity Level 2] Publish compliance-specific application requirements and test guidance. Establish standard compliance requirements and incorporate them into application development processes.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "G-PC-3-B",
                   "label": "Measure compliance to external requirements",
                   "description": "[Maturity Level 3] Measure and report on individual application's compliance with 3rd party requirements. Continuously measure compliance with external requirements and maintain real-time dashboards for stakeholder visibility.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -164,19 +189,25 @@
                   "ref": "G-EG-1-A",
                   "label": "Train all stakeholders for awareness",
                   "description": "[Maturity Level 1] Provide security awareness training for all personnel involved in software development. Conduct introductory training covering OWASP Top 10, secure coding basics, and the organization's security expectations.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "G-EG-2-A",
                   "label": "Customize security training",
                   "description": "[Maturity Level 2] Offer technology and role-specific guidance, including security best practices relevant to each role. Create role-based training programs tailored to developers, architects, testers, and managers.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "G-EG-3-A",
                   "label": "Standardize security guidance",
                   "description": "[Maturity Level 3] Standardized in-house guidance around the organization's secure software development. Maintain and evolve comprehensive, organization-specific security guidance that serves as a central reference for all development teams.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -190,19 +221,25 @@
                   "ref": "G-EG-1-B",
                   "label": "Identify security champions",
                   "description": "[Maturity Level 1] Identify a Security Champion within each development team. Security champions serve as the point of contact for security topics and help bridge the gap between security teams and development teams.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "G-EG-2-B",
                   "label": "Implement centers of excellence",
                   "description": "[Maturity Level 2] Develop a secure software center of excellence promoting thought leadership among practitioners in the organization. Create a team that drives security best practices and provides mentoring across the organization.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "G-EG-3-B",
                   "label": "Establish a security community",
                   "description": "[Maturity Level 3] Build a secure software community including all organization people involved in software development. Foster a mature security culture where security is a shared responsibility across all teams.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -232,19 +269,25 @@
                   "ref": "D-TA-1-A",
                   "label": "Perform application risk assessments",
                   "description": "[Maturity Level 1] A basic assessment of the application risk is performed to understand likelihood and impact of an attack. Use a simple method to evaluate the application risk per application, estimating the potential business impact that it poses for the organization in case of an attack. Evaluate the impact of a breach in the confidentiality, integrity and availability of the data or service.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "D-TA-2-A",
                   "label": "Inventorize risk profiles",
                   "description": "[Maturity Level 2] Understand the risk for all applications in the organization by centralizing the risk profile inventory for stakeholders. Create an extensive and standardized way to evaluate the risk of the application, including information security and privacy risk. Leverage business impact analysis to quantify and classify application risk.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "D-TA-3-A",
                   "label": "Periodic review of risk profiles",
                   "description": "[Maturity Level 3] Periodically review application risk profiles at regular intervals to ensure accuracy and reflect current state. The application portfolio of an organization changes, as well as the conditions and constraints in which an application lives. Stimulate teams to continuously question which changes in conditions might impact the risk profile.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -258,19 +301,25 @@
                   "ref": "D-TA-1-B",
                   "label": "Perform basic threat modeling",
                   "description": "[Maturity Level 1] Perform best-effort, risk-based threat modeling using brainstorming and existing diagrams with simple threat checklists. Threat modeling is a team exercise, including product owners, architects, security champions, and security testers. Use simple threat checklists, such as STRIDE. A good starting point is the existing diagrams that you annotate during discussion workshops.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "D-TA-2-B",
                   "label": "Standardize and scale threat modeling",
                   "description": "[Maturity Level 2] Standardize threat modeling training, processes, and tools to scale across the organization. Use a standardized threat modeling methodology and align this on your application risk levels. Train your architects, security champions, and other stakeholders on how to do practical threat modeling. Your methodology includes at least diagramming, threat identification, design flaw mitigations, and validation.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "D-TA-3-B",
                   "label": "Optimize threat modeling",
                   "description": "[Maturity Level 3] Continuously optimization and automation of your threat modeling methodology. Threat modeling is integrated into your SDLC and has become part of the developer security culture. Reusable risk patterns, comprising related threat libraries, design flaws, and security mitigations, are created and improved. You automate parts of your threat modeling process and consider threat modeling as code practices.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -292,19 +341,25 @@
                   "ref": "D-SR-1-A",
                   "label": "Identify security requirements",
                   "description": "[Maturity Level 1] High-level application security objectives are mapped to functional requirements. Perform a review of the functional requirements of the software project. Identify relevant security requirements for this functionality by reasoning on the desired confidentiality, integrity or availability of the service or data offered by the software project.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "D-SR-2-A",
                   "label": "Standardize and integrate security requirements",
                   "description": "[Maturity Level 2] Structured security requirements are available and utilized by developer teams. Achieve more systematic elicitation of security requirements by analysing different sources. Use a structured notation of security requirements across applications and an appropriate formalism that integrates well with how you specify other functional requirements.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "D-SR-3-A",
                   "label": "Develop a security requirements framework",
                   "description": "[Maturity Level 3] Build a requirements framework for product teams to utilize. Setup a security requirements framework to help projects elicit an appropriate and complete requirements set. The framework considers the different types and sources of requirements, provides categorisation of common requirements and reusable requirements, and gives clear guidance on quality.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -318,19 +373,25 @@
                   "ref": "D-SR-1-B",
                   "label": "Perform vendor assessments",
                   "description": "[Maturity Level 1] Evaluate the supplier based on organizational security requirements. Carry out a vendor assessment to understand the strengths and weaknesses of your suppliers. Use a basic checklist or conduct interviews to review their typical practices and deliveries.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "D-SR-2-B",
                   "label": "Discuss security responsibilities with suppliers",
                   "description": "[Maturity Level 2] Build security into supplier agreements in order to ensure compliance with organizational requirements. Discuss concrete responsibilities and expectations from your suppliers and your own organization and establish a contract with the supplier, including SLAs.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "D-SR-3-B",
                   "label": "Align security methodology with suppliers",
                   "description": "[Maturity Level 3] Ensure proper security coverage for external suppliers by providing clear objectives. Align maximally and integrate closely between the different parties. Use similar development paradigms and introduce regular milestones. Implement compensating controls where suppliers cannot meet objectives.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -352,19 +413,25 @@
                   "ref": "D-SA-1-A",
                   "label": "Adhere to basic security principles",
                   "description": "[Maturity Level 1] Teams are trained on the use of basic security principles during design. During design, technical staff on the product team use a short checklist of security principles including defense in depth, securing the weakest link, use of secure defaults, simplicity in design, secure failure, least privilege, and avoidance of security by obscurity.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "D-SA-2-A",
                   "label": "Provide preferred security solutions",
                   "description": "[Maturity Level 2] Establish common design patterns and security solutions for adoption. Identify shared infrastructure or services with security functionality such as single-sign-on services, access control, logging and monitoring services. Establish a set of best practices representing sound methods of implementing security functionality.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "D-SA-3-A",
                   "label": "Build reference architectures",
                   "description": "[Maturity Level 3] Reference architectures are utilized and continuously evaluated for adoption and appropriateness. Build a set of reference architectures that select and combine a verified set of security components to ensure a proper design of security. Reference platforms have advantages in shortening audit and security-related reviews, increasing efficiency in development, and lowering maintenance overhead.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -378,19 +445,25 @@
                   "ref": "D-SA-1-B",
                   "label": "Identify tools and technologies",
                   "description": "[Maturity Level 1] Elicit technologies, frameworks and integrations within the overall solution to identify risk. Identify the most important technologies, frameworks, tools and integrations being used for each application. Evaluate them for their security quality and raise important findings to be managed.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "D-SA-2-B",
                   "label": "Promote preferred tools and technologies",
                   "description": "[Maturity Level 2] Standardize technologies and frameworks to be used throughout the different applications. Identify commonly used technologies, frameworks and tools across software projects and create a recommended list. Consider incident history, track record for responding to vulnerabilities, and sufficient knowledge within the organization.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "D-SA-3-B",
                   "label": "Enforce the use of recommended technologies",
                   "description": "[Maturity Level 3] Impose the use of standard technologies on all software development. For all proprietary development, impose and monitor the use of standardized technology. Implement restrictions into build or deployment tools, or periodically review for correct use of frameworks.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -420,19 +493,25 @@
                   "ref": "I-SB-1-A",
                   "label": "Define a consistent build process",
                   "description": "[Maturity Level 1] Create a formal definition of the build process so that it becomes consistent and repeatable. Define the build process, breaking it down into a set of clear instructions to either be followed by a person or an automated tool. The build process definition describes the whole process end-to-end. The definition is stored centrally and accessible to any tools or people.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "I-SB-2-A",
                   "label": "Automate the build process",
                   "description": "[Maturity Level 2] Automate your build pipeline and secure the used tooling. Add security checks in the build pipeline. Automate the build process so that builds can be executed consistently anytime. Pay particular attention to the interfaces of build tools and how they can be locked-down. Add appropriate automated security checks (e.g. using SAST tools) in the pipeline.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "I-SB-3-A",
                   "label": "Enforce a security baseline during build",
                   "description": "[Maturity Level 3] Define mandatory security checks in the build process and ensure that building non-compliant artifacts fails. Define security checks suitable to be carried out during the build process, as well as minimum criteria for passing the build. Include the respective security checks in the build and enforce breaking the build process in case the predefined criteria are not met.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -446,19 +525,25 @@
                   "ref": "I-SB-1-B",
                   "label": "Identify application dependencies",
                   "description": "[Maturity Level 1] Create records with Bill of Materials of your applications and opportunistically analyze these. Keep a record of all dependencies used throughout the target production environment. Gather information about each dependency including where it is used, version, license, source, and support status. Check for known vulnerabilities.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "I-SB-2-B",
                   "label": "Review application dependencies for security",
                   "description": "[Maturity Level 2] Evaluate used dependencies and ensure timely reaction to situations posing risk to your applications. Establish a list of acceptable dependencies approved for use. Introduce a central repository. Review used dependencies regularly to ensure they remain correctly licensed, free of significant vulnerabilities, actively maintained, and current.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "I-SB-3-B",
                   "label": "Test application dependencies",
                   "description": "[Maturity Level 3] Analyze used dependencies for security issues in a comparable way to your own code. Maintain a whitelist of approved dependencies and versions, ensure the build process fails upon a non-whitelisted dependency. Perform security verification activities against dependencies including SAST and transitive dependency analysis.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -480,19 +565,25 @@
                   "ref": "I-SD-1-A",
                   "label": "Use a repeatable deployment process",
                   "description": "[Maturity Level 1] Formalize the deployment process and secure the used tooling and processes. Define the deployment process over all stages, breaking it down into a set of clear instructions. Deploy applications to production either using an automated process, or manually by personnel other than the developers. Ensure that developers do not need direct access to the production environment.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "I-SD-2-A",
                   "label": "Automate deployment and integrate security checks",
                   "description": "[Maturity Level 2] Automate the deployment process over all stages and introduce sensible security verification tests. Integrate automated security checks such as DAST and vulnerability scanning. Verify the integrity of deployed artefacts. Account for and audit all deployments to all stages.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "I-SD-3-A",
                   "label": "Verify the integrity of deployment artifacts",
                   "description": "[Maturity Level 3] Automatically verify integrity of all deployed software, independently of whether it's internally or externally developed. Include automatic verification of the integrity of software being deployed by checking their signatures against trusted certificates. Do not deploy artifacts if their signatures cannot be verified.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -506,19 +597,25 @@
                   "ref": "I-SD-1-B",
                   "label": "Protect application secrets in configuration and code",
                   "description": "[Maturity Level 1] Introduce basic protection measures to limit access to your production secrets. Developers should not have access to secrets or credentials for production environments. Store sensitive credentials and secrets for production systems with encryption-at-rest at all times.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "I-SD-2-B",
                   "label": "Include application secrets during deployment",
                   "description": "[Maturity Level 2] Inject secrets dynamically during deployment process from hardened storages and audit all human access to them. Have an automated process to add credentials and secrets to configuration files during the deployment process. Implement checks that detect the presence of secrets in code repositories.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "I-SD-3-B",
                   "label": "Enforce lifecycle management of application secrets",
                   "description": "[Maturity Level 3] Improve the lifecycle of application secrets by regularly generating them and by ensuring proper use. Implement lifecycle management for production secrets, and ensure the generation of new secrets as much as possible, and for every application instance. Ensure that all access to secrets is logged and reviewed.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -540,19 +637,25 @@
                   "ref": "I-DM-1-A",
                   "label": "Track security defects centrally",
                   "description": "[Maturity Level 1] Introduce a structured tracking of security defects and make knowledgeable decisions based on this information. Introduce a common definition of a security defect and define the most common ways of identifying these. Record and track all security defects in a defined location. Foster a culture of transparency and avoid blaming teams.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "I-DM-2-A",
                   "label": "Rate and track security defects",
                   "description": "[Maturity Level 2] Rate all security defects over the whole organization consistently and define SLAs for particular severity classes. Introduce and apply a well-defined rating methodology based on probability and expected impact. Introduce SLAs for timely fixing and centrally monitor and report on SLA breaches.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "I-DM-3-A",
                   "label": "Enforce an SLA for defect management",
                   "description": "[Maturity Level 3] Enforce the predefined SLAs and integrate your defect management system with other relevant tooling. Implement automated alerting on SLA breaches. Ensure defects are automatically transferred into the risk management process. Integrate with build, deployment, and monitoring systems.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -566,19 +669,25 @@
                   "ref": "I-DM-1-B",
                   "label": "Define basic defect metrics",
                   "description": "[Maturity Level 1] Regularly go over previously recorded security defects and derive quick wins from basic metrics. Extract basic metrics such as total defects versus verification activities, affected components, defect types and severity. Identify and carry out sensible quick win activities.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "I-DM-2-B",
                   "label": "Define advanced defect metrics",
                   "description": "[Maturity Level 2] Collect standardized defect management metrics and use these also for prioritization of centrally driven initiatives. Define, collect and calculate unified metrics across the whole organization including time to detect, time to resolve, windows of exposure, regressions, and accepted risk.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "I-DM-3-B",
                   "label": "Use metrics to improve the security strategy",
                   "description": "[Maturity Level 3] Continuously improve your security defect management metrics and correlate it with other sources. Regularly revisit the defect management metrics. Aggregate with threat intelligence and incident management metrics and use as input for organization-wide initiatives.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -608,19 +717,25 @@
                   "ref": "V-AA-1-A",
                   "label": "Assess application architecture",
                   "description": "[Maturity Level 1] Identify application and infrastructure architecture components and review for basic security provisioning. Create a view of the overall architecture and examine it for the correct provision of general security mechanisms such as authentication, authorization, user and rights management, secure communication, data protection, key management and log management.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "V-AA-2-A",
                   "label": "Standardize architecture assessment",
                   "description": "[Maturity Level 2] Standardize and document the assessment methodology for all applications in your organization. Verify the architecture for the correct provision of security mechanisms, as well as their correct interaction with system-level resources and other related applications. Assess for adequacy of all identified security and compliance requirements.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "V-AA-3-A",
                   "label": "Evaluate architecture effectiveness",
                   "description": "[Maturity Level 3] Continuously review and update the architecture review process, and confirm the validity of previously accepted architecture assessments. Regularly (at least annually) review all architecture assessment results, and trigger re-assessment if the results are older than necessary.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -634,19 +749,25 @@
                   "ref": "V-AA-1-B",
                   "label": "Verify threat mitigations",
                   "description": "[Maturity Level 1] Verify that each application in your organization has been reviewed for threats with a focus on understanding how the architecture mitigates common attacks. Verify that each identified threat has an adequate mitigation.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "V-AA-2-B",
                   "label": "Assess threat model completeness",
                   "description": "[Maturity Level 2] Analyze the architecture against known threats, using a standardized process. Ensure the threat model is complete and that mitigations are appropriate and effective. Feed findings back into the Secure Architecture practice.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "V-AA-3-B",
                   "label": "Review architecture mitigation effectiveness",
                   "description": "[Maturity Level 3] Regularly review and update the architecture to respond to new threats. Ensure continuous improvement of architectural mitigations. Evaluate the scalability and strategic alignment of security controls.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -668,19 +789,25 @@
                   "ref": "V-RT-1-A",
                   "label": "Test for security requirements",
                   "description": "[Maturity Level 1] Verify the implementation of security requirements by testing for them. For each security requirement, derive security test cases that verify the requirement. Focus on positive tests first: verify the control correctly implements the stated requirement.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "V-RT-2-A",
                   "label": "Derive test cases from security requirements",
                   "description": "[Maturity Level 2] From the security requirements, derive automated security test cases. Systematically generate test cases from requirements. Automate these tests and run them as part of the continuous integration pipeline.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "V-RT-3-A",
                   "label": "Establish regression testing",
                   "description": "[Maturity Level 3] Create security regression tests for all significant bugs found and fixed. Integrate security regression tests into the build and deploy pipeline. Ensure that all fixed security defects have corresponding regression tests.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -694,19 +821,25 @@
                   "ref": "V-RT-1-B",
                   "label": "Perform misuse/abuse testing",
                   "description": "[Maturity Level 1] Test for abuse/misuse of application features, focusing on the most critical functionality. Identify resources and features that could be misused. Perform basic negative tests such as trying to bypass authentication or access unauthorized data.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "V-RT-2-B",
                   "label": "Derive abuse test cases from security requirements",
                   "description": "[Maturity Level 2] Create misuse and abuse cases for important functionality, derived from functional requirements. Document misuse cases and create corresponding test cases. Consider the application from an attacker's perspective.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "V-RT-3-B",
                   "label": "Perform security stress testing",
                   "description": "[Maturity Level 3] Perform security stress testing against applications. Perform denial of service testing, advanced fuzzing, and other stress tests. Ensure the application can handle unexpected or malicious input gracefully.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -728,19 +861,25 @@
                   "ref": "V-ST-1-A",
                   "label": "Perform automated security testing",
                   "description": "[Maturity Level 1] Use automated security testing tools. Employ automated security testing tools such as SAST and DAST to identify common vulnerabilities. Integrate these tools into the development pipeline and process their output.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "V-ST-2-A",
                   "label": "Customize automated security testing",
                   "description": "[Maturity Level 2] Customize automated security testing for each application. Tune testing tools for the specific technology stack and application context. Increase frequency of testing and improve integration with the CI/CD pipeline.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "V-ST-3-A",
                   "label": "Integrate automated testing with build pipeline",
                   "description": "[Maturity Level 3] Integrate automated security testing into the build pipeline and fail the build on significant findings. Make security testing a mandatory quality gate. Ensure comprehensive coverage across all applications.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -754,19 +893,25 @@
                   "ref": "V-ST-1-B",
                   "label": "Perform manual security testing",
                   "description": "[Maturity Level 1] Perform manual security testing of high-risk components. Identify high-risk components and perform manual security testing on them. Use experienced security testers with knowledge of common attack techniques.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "V-ST-2-B",
                   "label": "Perform penetration testing",
                   "description": "[Maturity Level 2] Perform penetration testing for critical applications. Conduct regular penetration tests by experienced security testers. Prioritize testing of high-risk applications and newly developed functionality.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "V-ST-3-B",
                   "label": "Establish a continuous security testing program",
                   "description": "[Maturity Level 3] Integrate expert security testing into the development lifecycle. Establish an ongoing program of manual security testing, including bug bounty programs. Make advanced security testing an integral part of the development process.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -796,19 +941,25 @@
                   "ref": "O-IM-1-A",
                   "label": "Use best-effort incident detection",
                   "description": "[Maturity Level 1] Use available log data to perform best-effort detection of possible security incidents. Analyze available log data (e.g., access logs, application logs, infrastructure logs), to detect possible security incidents. With larger log volumes, employ automation techniques. Establish and share points of contact for formal creation of security incidents.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "O-IM-2-A",
                   "label": "Define an incident detection process",
                   "description": "[Maturity Level 2] Follow an established, well-documented process for incident detection, with emphasis on automated log evaluation. Establish a dedicated owner for the incident detection process. The process typically relies on a high degree of automation, collecting and correlating log data from different sources. Use a checklist covering expected attack vectors and known kill chains.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "O-IM-3-A",
                   "label": "Improve the incident detection process",
                   "description": "[Maturity Level 3] Use a proactively managed process for detection of incidents. Ensure the checklist for suspicious event detection is correlated from external sources, past security incidents, and threat model outcomes. Use correlation of logs for all reasonable incident scenarios. The quality of detection does not depend on the time or day of the event.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -822,19 +973,25 @@
                   "ref": "O-IM-1-B",
                   "label": "Create an incident response plan",
                   "description": "[Maturity Level 1] Identify roles and responsibilities for incident response. Recognize incident response as a competence, define a responsible owner, and define participants of the process. Assign a single point of contact known to all relevant stakeholders. Document all actions taken during security incidents.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "O-IM-2-B",
                   "label": "Define an incident response process",
                   "description": "[Maturity Level 2] Establish a formal incident response process and ensure staff are properly trained in performing their roles. Document common scenarios, rules for triaging, involvement of stakeholders, and root-cause analysis processes. Ensure a knowledgeable and trained incident response team is available both during and outside business hours.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "O-IM-3-B",
                   "label": "Establish an incident response team",
                   "description": "[Maturity Level 3] Employ a dedicated, well-trained incident response team. Establish a dedicated team responsible for continuous process improvement with the help of regular root cause analyses. Document detailed procedures and automate where appropriate. Carry out incident and emergency exercises regularly.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -856,19 +1013,25 @@
                   "ref": "O-EM-1-A",
                   "label": "Use best-effort hardening",
                   "description": "[Maturity Level 1] Perform best-effort hardening of configurations, based on readily available information. Apply secure configuration to stack elements based on readily available guidance such as open source projects, vendor documentation, and blog articles. Identify key elements of common technology stacks and establish configuration standards.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "O-EM-2-A",
                   "label": "Establish hardening baselines",
                   "description": "[Maturity Level 2] Perform consistent hardening of configurations, following established baselines and guidance. Establish configuration hardening baselines for all components in each technology stack. Develop configuration guides and require product teams to apply baselines to all new and existing systems.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "O-EM-3-A",
                   "label": "Perform continuous configuration monitoring",
                   "description": "[Maturity Level 3] Actively monitor configurations for non-conformance to baselines, and handle detected occurrences as security defects. Perform regular checks against established baselines. When non-conforming configurations are detected, treat each occurrence as a security finding and manage corrective actions within the Defect Management practice.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -882,19 +1045,25 @@
                   "ref": "O-EM-1-B",
                   "label": "Practice best-effort patching",
                   "description": "[Maturity Level 1] Perform best-effort patching of system and application components. Identify applications and third-party components which need to be updated or patched. Identification and patching activities are best-effort and ad hoc. Ensure teams can determine the versions of all components in use.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "O-EM-2-B",
                   "label": "Formalize patch management",
                   "description": "[Maturity Level 2] Perform regular patching of system and application components, across the full stack. Ensure timely delivery of patches to customers. Develop and follow a well-defined process with regular schedules aligned with vendor update calendars. Create guidance for prioritizing component patching.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "O-EM-3-B",
                   "label": "Enforce timely patch management",
                   "description": "[Maturity Level 3] Actively monitor update status and manage missing patches as security defects. Proactively obtain vulnerability and update information for components. Develop management dashboards to track compliance with patching processes and SLAs. Monitor external threat intelligence sources for zero day vulnerabilities.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }
@@ -916,19 +1085,25 @@
                   "ref": "O-OM-1-A",
                   "label": "Organize basic data protections",
                   "description": "[Maturity Level 1] Implement basic data protection practices. Understand the types and sensitivity of data stored and processed by your applications, and maintain awareness of the fate of processed data. Protect and handle all data associated with a given application according to protection requirements applying to the most sensitive data stored and processed.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "O-OM-2-A",
                   "label": "Establish a data catalog",
                   "description": "[Maturity Level 2] Develop data catalog and establish data protection policy. Identify the data stored, processed, and transmitted by applications, and capture information regarding their types, sensitivity levels, and storage locations. Establish processes and procedures for protecting and preserving data throughout their lifetime.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "O-OM-3-A",
                   "label": "Respond to data breaches",
                   "description": "[Maturity Level 3] Automate detection of policy non-compliance, and audit compliance periodically. Regularly review and update data catalog and data protection policy. Implement technical controls to enforce compliance with your Data Protection Policy, and put monitoring in place to detect attempted or actual violations.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             },
@@ -942,19 +1117,25 @@
                   "ref": "O-OM-1-B",
                   "label": "Identify unused applications",
                   "description": "[Maturity Level 1] Decommission unused applications and services as identified. Manage customer upgrades/migrations individually. Identify unused applications on an ad hoc basis, either by chance observation, or by occasionally performing a review.",
-                  "tags": ["maturity:1"]
+                  "tags": [
+                    "maturity:1"
+                  ]
                 },
                 {
                   "ref": "O-OM-2-B",
                   "label": "Formalize decommissioning process",
                   "description": "[Maturity Level 2] Develop repeatable decommissioning processes for unused systems/services, and for migration from legacy dependencies. Manage legacy migration roadmaps for customers. Follow an established process for removing all relevant accounts, firewall rules, data, etc. from the operational environment.",
-                  "tags": ["maturity:2"]
+                  "tags": [
+                    "maturity:2"
+                  ]
                 },
                 {
                   "ref": "O-OM-3-B",
                   "label": "Review application lifecycle state regularly",
                   "description": "[Maturity Level 3] Proactively manage migration roadmaps, for both unsupported end-of-life dependencies, and legacy versions of delivered software. Regularly evaluate the lifecycle state and support status of every software asset and underlying infrastructure component. Follow a well-defined process for actively mitigating security risks as assets approach end-of-life.",
-                  "tags": ["maturity:3"]
+                  "tags": [
+                    "maturity:3"
+                  ]
                 }
               ]
             }

--- a/frameworks/pci-card-production-logical.json
+++ b/frameworks/pci-card-production-logical.json
@@ -1,6 +1,10 @@
 {
-  "name": "PCI Card Production and Provisioning Logical Security v3.0.1",
-  "short_name": "PCI Card Production and Provisioning Logical Security v3.0.1",
+  "key": "pci-card-production-logical",
+  "name": "PCI Card Production and Provisioning Logical Security",
+  "short_name": "PCI CP Logical",
+  "version": "3.0.1",
+  "publisher": "PCI Security Standards Council",
+  "source_url": "https://www.pcisecuritystandards.org/document_library",
   "last_updated": "2026-01-22",
   "description": "PCI SSC requirements for logical security in card production and provisioning environments.",
   "category": "framework",

--- a/frameworks/pci-card-production-physical.json
+++ b/frameworks/pci-card-production-physical.json
@@ -1,6 +1,10 @@
 {
-  "name": "PCI Card Production and Provisioning Physical Security v3.0.1",
-  "short_name": "PCI Card Production and Provisioning Physical Security v3.0.1",
+  "key": "pci-card-production-physical",
+  "name": "PCI Card Production and Provisioning Physical Security",
+  "short_name": "PCI CP Physical",
+  "version": "3.0.1",
+  "publisher": "PCI Security Standards Council",
+  "source_url": "https://www.pcisecuritystandards.org/document_library",
   "last_updated": "2026-01-22",
   "description": "PCI SSC requirements for physical security in card production and provisioning environments.",
   "category": "framework",

--- a/frameworks/pci-dss-4-0-1.json
+++ b/frameworks/pci-dss-4-0-1.json
@@ -1,6 +1,13 @@
 {
-  "name": "PCI DSS 4.0.1",
-  "short_name": "PCI DSS 4.0.1",
+  "key": "pci-dss-4-0-1",
+  "name": "PCI DSS",
+  "short_name": "PCI DSS",
+  "version": "4.0.1",
+  "publisher": "PCI Security Standards Council",
+  "source_url": "https://www.pcisecuritystandards.org/document_library",
+  "scf_keys": [
+    "pci-dss-4-0-1"
+  ],
   "last_updated": "2026-01-22",
   "description": "Payment card industry standard for protecting cardholder data through security controls.",
   "category": "framework",

--- a/frameworks/us-cmmc-2-0.json
+++ b/frameworks/us-cmmc-2-0.json
@@ -1,6 +1,15 @@
 {
+  "key": "us-cmmc-2-0",
   "name": "Cybersecurity Maturity Model Certification (CMMC)",
   "short_name": "CMMC",
+  "version": "2.0",
+  "publisher": "US Department of Defense",
+  "source_url": "https://dodcio.defense.gov/CMMC/",
+  "scf_keys": [
+    "us-cmmc-2-0-level-1",
+    "us-cmmc-2-0-level-2",
+    "us-cmmc-2-0-level-3"
+  ],
   "last_updated": "2026-03-17",
   "description": "The Cybersecurity Maturity Model Certification (CMMC) is a unifying cybersecurity standard for the U.S. defense industrial base (DIB).",
   "category": "framework",

--- a/frameworks/us-hipaa.json
+++ b/frameworks/us-hipaa.json
@@ -1,6 +1,13 @@
 {
+  "key": "us-hipaa",
   "name": "HIPAA",
   "short_name": "HIPAA",
+  "publisher": "US Department of Health and Human Services",
+  "source_url": "https://www.hhs.gov/hipaa/",
+  "scf_keys": [
+    "us-hipaa-administrative-simplification-2013",
+    "us-hipaa-security-rule-nist-sp-800-66-r2"
+  ],
   "last_updated": "2025-07-21",
   "description": "U.S. federal law establishing privacy and security standards for protected health information (45 CFR Part 164).",
   "category": "framework",

--- a/frameworks/us-nerc-cip.json
+++ b/frameworks/us-nerc-cip.json
@@ -1,6 +1,12 @@
 {
+  "key": "us-nerc-cip",
   "name": "NERC CIP",
   "short_name": "NERC CIP",
+  "publisher": "North American Electric Reliability Corporation",
+  "source_url": "https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx",
+  "scf_keys": [
+    "us-nerc-cip-2024"
+  ],
   "last_updated": "2025-09-30",
   "description": "Mandatory cybersecurity standards for North American bulk electric system operators.",
   "category": "framework",

--- a/frameworks/us-ny-dfs-23-nycrr500.json
+++ b/frameworks/us-ny-dfs-23-nycrr500.json
@@ -1,6 +1,13 @@
 {
-  "name": "NY DFS",
+  "key": "us-ny-dfs-23-nycrr500",
+  "name": "NY DFS 23 NYCRR Part 500",
   "short_name": "NY DFS",
+  "version": "2023 Amd 2",
+  "publisher": "New York State Department of Financial Services",
+  "source_url": "https://www.dfs.ny.gov/industry_guidance/cyber_filings/cybersecurity_regulation",
+  "scf_keys": [
+    "us-ny-dfs-23-nycrr500-2023-amd-2"
+  ],
   "last_updated": "2025-07-17",
   "description": "New York State cybersecurity regulation (23 NYCRR 500) for financial services companies.",
   "category": "framework",


### PR DESCRIPTION
## Summary

- Adds required `key` field (hand-set slug; matches SCF where the framework exists in SCF) and optional `scf_keys` array (SCF framework slugs that alias to this framework).
- Splits version-bearing suffixes out of `name`/`short_name` into the dedicated `version` field.
- Renames each JSON to `<key>.json` so filename and canonical identifier match.
- Populates `publisher` and `source_url` where known.

## Why

Without this, eload was double-loading frameworks: episki-frameworks would create one row (e.g. `cis-critical-security-controls`) while SCF crosswalk references would create a separate row (e.g. `cis-csc-8-1`) with zero controls. The new `scf_keys` field lets eload's `load-scf` route SCF mapping refs to the existing episki framework instead of creating an empty stub.

After this PR + the eload changes, `cis-csc-8-1` is a single framework with the full 171-control tree from this repo *plus* 429 inbound SCF mapping refs. Similarly for SOC 2, GDPR, NIST CSF, PCI DSS, ISO 27001/27002, HIPAA, NY DFS, NERC CIP, UK Cyber Essentials, NIST AI RMF, NIST SP 800-66, and CMMC (multiple SCF levels collapsed to one CMMC framework).

## Key conventions

| Case | Convention |
|---|---|
| Exists in SCF | `key` matches SCF's slug exactly (preserves SCF's versioning style) |
| Multiple SCF rows for one framework | `scf_keys` lists all matching SCF slugs (CIS IG1/2/3, CMMC L1/L2/L3, HIPAA AS + Security Rule) |
| Repo-only | `key` is chosen for clarity (e.g. `owasp-samm`, `pci-card-production-logical`) |

## Validation

- `bun run scripts/validate-schema.ts` — passes
- `bun run scripts/validate-json.ts` — passes

## Test plan

- [ ] Merge this PR
- [ ] In eload: `bun install` to pull the new file layout
- [ ] In eload: `bun run load-controls --local --apply` then `bun run load-scf --local --apply`
- [ ] Confirm `select key, count(*) from catalog.frameworks group by key` shows no duplicate `cis-*` / `cmmc-*` stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)