### PR TITLE
fix(hipaa): strip markdown from labels/descriptions, flag section groups

### DIFF
--- a/frameworks/us-hipaa.json
+++ b/frameworks/us-hipaa.json
@@ -8,7 +8,7 @@
     "us-hipaa-administrative-simplification-2013",
     "us-hipaa-security-rule-nist-sp-800-66-r2"
   ],
-  "last_updated": "2025-07-21",
+  "last_updated": "2026-06-26",
   "description": "U.S. federal law establishing privacy and security standards for protected health information (45 CFR Part 164).",
   "category": "framework",
   "keywords": [
@@ -18,14 +18,17 @@
   "controls": [
     {
       "ref": "Breach Notification Rule",
+      "group": true,
       "controls": [
         {
           "ref": "164.404",
           "label": "Notification to individuals.",
+          "group": true,
           "controls": [
             {
               "ref": "164.404(a)",
               "label": "Standard",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.404(a)(1)",
@@ -35,23 +38,25 @@
                 {
                   "ref": "164.404(a)(2)",
                   "label": "Breaches treated as discovered",
-                  "description": "For purposes of [paragraph (a)(1)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(a)(1)) of this section, [§§ 164.406(a)](https://www.ecfr.gov/current/title-45/section-164.406#p-164.406(a)), and [164.408(a)](https://www.ecfr.gov/current/title-45/section-164.408#p-164.408(a)), a breach shall be treated as discovered by a covered entity as of the first day on which such breach is known to the covered entity, or, by exercising reasonable diligence would have been known to the covered entity. A covered entity shall be deemed to have knowledge of a breach if such breach is known, or by exercising reasonable diligence would have been known, to any person, other than the person committing the breach, who is a workforce member or agent of the covered entity (determined in accordance with the federal common law of agency)."
+                  "description": "For purposes of paragraph (a)(1) of this section, §§ 164.406(a), and 164.408(a), a breach shall be treated as discovered by a covered entity as of the first day on which such breach is known to the covered entity, or, by exercising reasonable diligence would have been known to the covered entity. A covered entity shall be deemed to have knowledge of a breach if such breach is known, or by exercising reasonable diligence would have been known, to any person, other than the person committing the breach, who is a workforce member or agent of the covered entity (determined in accordance with the federal common law of agency)."
                 }
               ]
             },
             {
               "ref": "164.404(b)",
               "label": "Implementation specification: Timeliness of notification",
-              "description": "Except as provided in [§ 164.412](https://www.ecfr.gov/current/title-45/section-164.412), a covered entity shall provide the notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(a)) of this section without unreasonable delay and in no case later than 60 calendar days after discovery of a breach."
+              "description": "Except as provided in § 164.412, a covered entity shall provide the notification required by paragraph (a) of this section without unreasonable delay and in no case later than 60 calendar days after discovery of a breach."
             },
             {
               "ref": "164.404(c)",
               "label": "Implementation specifications: Content of notification",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.404(c)(1)",
                   "label": "Elements.",
-                  "description": "The notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(a)) of this section shall include, to the extent possible:",
+                  "description": "The notification required by paragraph (a) of this section shall include, to the extent possible:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.404(c)(1)(A)",
@@ -78,18 +83,20 @@
                 {
                   "ref": "164.404(c)(2)",
                   "label": "Plain language requirement",
-                  "description": "The notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(a)) of this section shall be written in plain language."
+                  "description": "The notification required by paragraph (a) of this section shall be written in plain language."
                 }
               ]
             },
             {
               "ref": "164.404(d)",
-              "label": "**Implementation specifications: Methods of individual notification**",
-              "description": "The notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(a)) of this section shall be provided in the following form:",
+              "label": "Implementation specifications: Methods of individual notification",
+              "description": "The notification required by paragraph (a) of this section shall be provided in the following form:",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.404(d)(1)",
                   "label": "Written notice.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.404(d)(1)(i)",
@@ -97,14 +104,15 @@
                     },
                     {
                       "ref": "164.404(d)(1)(ii)",
-                      "label": "If the covered entity knows the individual is deceased and has the address of the next of kin or personal representative of the individual (as specified under [§ 164.502(g)(4)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(4)) of subpart E), written notification by first-class mail to either the next of kin or personal representative of the individual. The notification may be provided in one or more mailings as information is available."
+                      "label": "If the covered entity knows the individual is deceased and has the address of the next of kin or personal representative of the individual (as specified under § 164.502(g)(4) of subpart E), written notification by first-class mail to either the next of kin or personal representative of the individual. The notification may be provided in one or more mailings as information is available."
                     }
                   ]
                 },
                 {
                   "ref": "164.404(d)(2)",
                   "label": "Substitute notice.",
-                  "description": "In the case in which there is insufficient or out-of-date contact information that precludes written notification to the individual under [paragraph (d)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(d)(1)(i)) of this section, a substitute form of notice reasonably calculated to reach the individual shall be provided. Substitute notice need not be provided in the case in which there is insufficient or out-of-date contact information that precludes written notification to the next of kin or personal representative of the individual under paragraph (d)(1)(ii).",
+                  "description": "In the case in which there is insufficient or out-of-date contact information that precludes written notification to the individual under paragraph (d)(1)(i) of this section, a substitute form of notice reasonably calculated to reach the individual shall be provided. Substitute notice need not be provided in the case in which there is insufficient or out-of-date contact information that precludes written notification to the next of kin or personal representative of the individual under paragraph (d)(1)(ii).",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.404(d)(2)(i)",
@@ -113,6 +121,7 @@
                     {
                       "ref": "164.404(d)(2)(ii)",
                       "label": "In the case in which there is insufficient or out-of-date contact information for 10 or more individuals, then such substitute notice shall:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.404(d)(2)(ii)(A)",
@@ -129,7 +138,7 @@
                 {
                   "ref": "164.404(d)(3)",
                   "label": "Additional notice in urgent situations",
-                  "description": "In any case deemed by the covered entity to require urgency because of possible imminent misuse of unsecured protected health information, the covered entity may provide information to individuals by telephone or other means, as appropriate, in addition to notice provided under [paragraph (d)(1)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(d)(1)) of this section."
+                  "description": "In any case deemed by the covered entity to require urgency because of possible imminent misuse of unsecured protected health information, the covered entity may provide information to individuals by telephone or other means, as appropriate, in addition to notice provided under paragraph (d)(1) of this section."
                 }
               ]
             }
@@ -138,52 +147,56 @@
         {
           "ref": "164.406",
           "label": "Notification to the media.",
+          "group": true,
           "controls": [
             {
               "ref": "164.406(a)",
               "label": "Standard",
-              "description": "For a breach of unsecured protected health information involving more than 500 residents of a State or jurisdiction, a covered entity shall, following the discovery of the breach as provided in [§ 164.404(a)(2)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(a)(2)), notify prominent media outlets serving the State or jurisdictio"
+              "description": "For a breach of unsecured protected health information involving more than 500 residents of a State or jurisdiction, a covered entity shall, following the discovery of the breach as provided in § 164.404(a)(2), notify prominent media outlets serving the State or jurisdictio"
             },
             {
               "ref": "164.406(b)",
               "label": "Implementation specification: Timeliness of notification",
-              "description": "Except as provided in [§ 164.412](https://www.ecfr.gov/current/title-45/section-164.412), a covered entity shall provide the notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.406#p-164.406(a)) of this section without unreasonable delay and in no case later than 60 calendar days after discovery of a breach."
+              "description": "Except as provided in § 164.412, a covered entity shall provide the notification required by paragraph (a) of this section without unreasonable delay and in no case later than 60 calendar days after discovery of a breach."
             },
             {
               "ref": "164.406(c)",
               "label": "Implementation specifications: Content of notification.",
-              "description": "The notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.406#p-164.406(a)) of this section shall meet the requirements of [§ 164.404(c)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(c))."
+              "description": "The notification required by paragraph (a) of this section shall meet the requirements of § 164.404(c)."
             }
           ]
         },
         {
           "ref": "164.408",
           "label": "Notification to the Secretary.",
+          "group": true,
           "controls": [
             {
               "ref": "164.408(a)",
               "label": "Standard.",
-              "description": "A covered entity shall, following the discovery of a breach of unsecured protected health information as provided in [§ 164.404(a)(2)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(a)(2)), notify the Secretary."
+              "description": "A covered entity shall, following the discovery of a breach of unsecured protected health information as provided in § 164.404(a)(2), notify the Secretary."
             },
             {
               "ref": "164.408(b)",
               "label": "Implementation specifications: Breaches involving 500 or more individuals",
-              "description": "For breaches of unsecured protected health information involving 500 or more individuals, a covered entity shall, except as provided in [§ 164.412](https://www.ecfr.gov/current/title-45/section-164.412), provide the notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.408#p-164.408(a)) of this section contemporaneously with the notice required by [§ 164.404(a)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(a)) and in the manner specified on the HHS Web site."
+              "description": "For breaches of unsecured protected health information involving 500 or more individuals, a covered entity shall, except as provided in § 164.412, provide the notification required by paragraph (a) of this section contemporaneously with the notice required by § 164.404(a) and in the manner specified on the HHS Web site."
             },
             {
               "ref": "164.408(c)",
               "label": "Implementation specifications: Breaches involving less than 500 individuals.",
-              "description": "For breaches of unsecured protected health information involving less than 500 individuals, a covered entity shall maintain a log or other documentation of such breaches and, not later than 60 days after the end of each calendar year, provide the notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.408#p-164.408(a)) of this section for breaches discovered during the preceding calendar year, in the manner specified on the HHS web site."
+              "description": "For breaches of unsecured protected health information involving less than 500 individuals, a covered entity shall maintain a log or other documentation of such breaches and, not later than 60 days after the end of each calendar year, provide the notification required by paragraph (a) of this section for breaches discovered during the preceding calendar year, in the manner specified on the HHS web site."
             }
           ]
         },
         {
           "ref": "164.410",
           "label": "Notification by a business associate.",
+          "group": true,
           "controls": [
             {
               "ref": "164.410(a)",
               "label": "Standard",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.410(a)(1)",
@@ -193,26 +206,27 @@
                 {
                   "ref": "164.410(a)(2)",
                   "label": "Breaches treated as discovered",
-                  "description": "For purposes of [paragraph (a)(1)](https://www.ecfr.gov/current/title-45/section-164.410#p-164.410(a)(1)) of this section, a breach shall be treated as discovered by a business associate as of the first day on which such breach is known to the business associate or, by exercising reasonable diligence, would have been known to the business associate. A business associate shall be deemed to have knowledge of a breach if the breach is known, or by exercising reasonable diligence would have been known, to any person, other than the person committing the breach, who is an employee, officer, or other agent of the business associate (determined in accordance with the Federal common law of agency)."
+                  "description": "For purposes of paragraph (a)(1) of this section, a breach shall be treated as discovered by a business associate as of the first day on which such breach is known to the business associate or, by exercising reasonable diligence, would have been known to the business associate. A business associate shall be deemed to have knowledge of a breach if the breach is known, or by exercising reasonable diligence would have been known, to any person, other than the person committing the breach, who is an employee, officer, or other agent of the business associate (determined in accordance with the Federal common law of agency)."
                 }
               ]
             },
             {
               "ref": "164.410(b)",
               "label": "Implementation specifications: Timeliness of notification",
-              "description": "Except as provided in [§ 164.412](https://www.ecfr.gov/current/title-45/section-164.412), a business associate shall provide the notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.410#p-164.410(a)) of this section without unreasonable delay and in no case later than 60 calendar days after discovery of a breach."
+              "description": "Except as provided in § 164.412, a business associate shall provide the notification required by paragraph (a) of this section without unreasonable delay and in no case later than 60 calendar days after discovery of a breach."
             },
             {
               "ref": "164.410(c)",
               "label": "Implementation specifications: Content of notification.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.410(c)(1)",
-                  "label": "The notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.410#p-164.410(a)) of this section shall include, to the extent possible, the identification of each individual whose unsecured protected health information has been, or is reasonably believed by the business associate to have been, accessed, acquired, used, or disclosed during the breach."
+                  "label": "The notification required by paragraph (a) of this section shall include, to the extent possible, the identification of each individual whose unsecured protected health information has been, or is reasonably believed by the business associate to have been, accessed, acquired, used, or disclosed during the breach."
                 },
                 {
                   "ref": "164.410(c)(2)",
-                  "label": "A business associate shall provide the covered entity with any other available information that the covered entity is required to include in notification to the individual under [§ 164.404(c)](https://www.ecfr.gov/current/title-45/section-164.404#p-164.404(c)) at the time of the notification required by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.410#p-164.410(a)) of this section or promptly thereafter as information becomes available."
+                  "label": "A business associate shall provide the covered entity with any other available information that the covered entity is required to include in notification to the individual under § 164.404(c) at the time of the notification required by paragraph (a) of this section or promptly thereafter as information becomes available."
                 }
               ]
             }
@@ -222,6 +236,7 @@
           "ref": "164.412",
           "label": "Law enforcement delay.",
           "description": "If a law enforcement official states to a covered entity or business associate that a notification, notice, or posting required under this subpart would impede a criminal investigation or cause damage to national security, a covered entity or business associate shall:",
+          "group": false,
           "controls": [
             {
               "ref": "164.412(a)",
@@ -229,23 +244,24 @@
             },
             {
               "ref": "164.412(b)",
-              "label": "If the statement is made orally, document the statement, including the identity of the official making the statement, and delay the notification, notice, or posting temporarily and no longer than 30 days from the date of the oral statement, unless a written statement as described in [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.412#p-164.412(a)) of this section is submitted during that time."
+              "label": "If the statement is made orally, document the statement, including the identity of the official making the statement, and delay the notification, notice, or posting temporarily and no longer than 30 days from the date of the oral statement, unless a written statement as described in paragraph (a) of this section is submitted during that time."
             }
           ]
         },
         {
           "ref": "164.414",
           "label": "Administrative requirements and burden of proof.",
+          "group": true,
           "controls": [
             {
               "ref": "164.414(a)",
               "label": "Administrative requirements.",
-              "description": "A covered entity is required to comply with the administrative requirements of [§ 164.530(b)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(b)), [(d)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(d)), [(e)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(e)), [(g)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(g)), [(h)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(h)), [(i)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(i)), and [(j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)) with respect to the requirements of this subpart."
+              "description": "A covered entity is required to comply with the administrative requirements of § 164.530(b), (d), (e), (g), (h), (i), and (j) with respect to the requirements of this subpart."
             },
             {
               "ref": "164.414(b)",
-              "label": "**Burden of proof.**",
-              "description": "In the event of a use or disclosure in violation of subpart E, the covered entity or business associate, as applicable, shall have the burden of demonstrating that all notifications were made as required by this subpart or that the use or disclosure did not constitute a breach, as defined at [§ 164.402](https://www.ecfr.gov/current/title-45/section-164.402)."
+              "label": "Burden of proof.",
+              "description": "In the event of a use or disclosure in violation of subpart E, the covered entity or business associate, as applicable, shall have the burden of demonstrating that all notifications were made as required by this subpart or that the use or disclosure did not constitute a breach, as defined at § 164.402."
             }
           ]
         }
@@ -253,20 +269,24 @@
     },
     {
       "ref": "Privacy Rule",
+      "group": true,
       "controls": [
         {
           "ref": "164.502",
           "label": "Uses and disclosures of protected health information: General rules.",
+          "group": true,
           "controls": [
             {
               "ref": "164.502(a)",
               "label": "Standard.",
               "description": "A covered entity or business associate may not use or disclose protected health information, except as permitted or required by this subpart or by subpart C of part 160 of this subchapter.",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.502(a)(1)",
                   "label": "Covered entities: Permitted uses and disclosures",
                   "description": "A covered entity is permitted to use or disclose protected health information as follows:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.502(a)(1)(i)",
@@ -274,23 +294,24 @@
                     },
                     {
                       "ref": "164.502(a)(1)(ii)",
-                      "label": "For treatment, payment, or health care operations, as permitted by and in compliance with [§ 164.506](https://www.ecfr.gov/current/title-45/section-164.506);"
+                      "label": "For treatment, payment, or health care operations, as permitted by and in compliance with § 164.506;"
                     },
                     {
                       "ref": "164.502(a)(1)(iii)",
-                      "label": "Incident to a use or disclosure otherwise permitted or required by this subpart, provided that the covered entity has complied with the applicable requirements of [§§ 164.502(b)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(b)), [164.514(d)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(d)), and [164.530(c)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(c)) with respect to such otherwise permitted or required use or disclosure;"
+                      "label": "Incident to a use or disclosure otherwise permitted or required by this subpart, provided that the covered entity has complied with the applicable requirements of §§ 164.502(b), 164.514(d), and 164.530(c) with respect to such otherwise permitted or required use or disclosure;"
                     },
                     {
                       "ref": "164.502(a)(1)(iv)",
-                      "label": "Except for uses and disclosures prohibited under [§ 164.502(a)(5)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(i)), pursuant to and in compliance with a valid authorization under [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508);"
+                      "label": "Except for uses and disclosures prohibited under § 164.502(a)(5)(i), pursuant to and in compliance with a valid authorization under § 164.508;"
                     },
                     {
                       "ref": "164.502(a)(1)(v)",
-                      "label": "Pursuant to an agreement under, or as otherwise permitted by, [§ 164.510](https://www.ecfr.gov/current/title-45/section-164.510); and"
+                      "label": "Pursuant to an agreement under, or as otherwise permitted by, § 164.510; and"
                     },
                     {
                       "ref": "164.502(a)(1)(vi)",
                       "label": "As permitted by and in compliance with any of the following:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.502(a)(1)(vi)(A)",
@@ -298,7 +319,7 @@
                         },
                         {
                           "ref": "164.502(a)(1)(vi)(B)",
-                          "label": "Section 164.512 and, where applicable, [§ 164.509](https://www.ecfr.gov/current/title-45/section-164.509)."
+                          "label": "Section 164.512 and, where applicable, § 164.509."
                         },
                         {
                           "ref": "164.502(a)(1)(vi)(C)",
@@ -312,10 +333,11 @@
                   "ref": "164.502(a)(2)",
                   "label": "Covered entities: Required disclosures",
                   "description": "A covered entity is required to disclose protected health information:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.502(a)(2)(i)",
-                      "label": "To an individual, when requested under, and required by [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524) or [§ 164.528](https://www.ecfr.gov/current/title-45/section-164.528); and"
+                      "label": "To an individual, when requested under, and required by § 164.524 or § 164.528; and"
                     },
                     {
                       "ref": "164.502(a)(2)(ii)",
@@ -326,12 +348,13 @@
                 {
                   "ref": "164.502(a)(3)",
                   "label": "Business associates: Permitted uses and disclosures",
-                  "description": "A business associate may use or disclose protected health information only as permitted or required by its business associate contract or other arrangement pursuant to [§ 164.504(e)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)) or as required by law. The business associate may not use or disclose protected health information in a manner that would violate the requirements of this subpart, if done by the covered entity, except for the purposes specified under [§ 164.504(e)(2)(i)(A)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(2)(i)(A)) or [(B)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(2)(i)(B)) if such uses or disclosures are permitted by its contract or other arrangement."
+                  "description": "A business associate may use or disclose protected health information only as permitted or required by its business associate contract or other arrangement pursuant to § 164.504(e) or as required by law. The business associate may not use or disclose protected health information in a manner that would violate the requirements of this subpart, if done by the covered entity, except for the purposes specified under § 164.504(e)(2)(i)(A) or (B) if such uses or disclosures are permitted by its contract or other arrangement."
                 },
                 {
                   "ref": "164.502(a)(4)",
                   "label": "Business associates: Required uses and disclosures",
                   "description": "A business associate is required to disclose protected health information:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.502(a)(4)(i)",
@@ -339,22 +362,25 @@
                     },
                     {
                       "ref": "164.502(a)(4)(ii)",
-                      "label": "To the covered entity, individual, or individual's designee, as necessary to satisfy a covered entity's obligations under [§ 164.524(c)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(c)(2)(ii)) and [(3)(ii)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(3)(ii)) with respect to an individual's request for an electronic copy of protected health information."
+                      "label": "To the covered entity, individual, or individual's designee, as necessary to satisfy a covered entity's obligations under § 164.524(c)(2)(ii) and (3)(ii) with respect to an individual's request for an electronic copy of protected health information."
                     }
                   ]
                 },
                 {
                   "ref": "164.502(a)(5)",
                   "label": "Prohibited uses and disclosures",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.502(a)(5)(i)",
                       "label": "se and disclosure of genetic information for underwriting purposes",
-                      "description": "Notwithstanding any other provision of this subpart, a health plan, excluding an issuer of a long-term care policy falling within paragraph (1)(viii) of the definition of *health plan,* shall not use or disclose protected health information that is genetic information for underwriting purposes. For purposes of [paragraph (a)(5)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(i)) of this section, underwriting purposes means, with respect to a health plan:",
+                      "description": "Notwithstanding any other provision of this subpart, a health plan, excluding an issuer of a long-term care policy falling within paragraph (1)(viii) of the definition of health plan, shall not use or disclose protected health information that is genetic information for underwriting purposes. For purposes of paragraph (a)(5)(i) of this section, underwriting purposes means, with respect to a health plan:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.502(a)(5)(i)(A)",
-                          "label": "Except as provided in [paragraph (a)(5)(i)(B)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(i)(B)) of this section:",
+                          "label": "Except as provided in paragraph (a)(5)(i)(B) of this section:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.502(a)(5)(i)(A)(1)",
@@ -383,50 +409,53 @@
                     {
                       "ref": "164.502(a)(5)(ii)",
                       "label": "Sale of protected health information:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.502(a)(5)(ii)(A)",
-                          "label": "Except pursuant to and in compliance with [§ 164.508(a)(4)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(a)(4)), a covered entity or business associate may not sell protected health information."
+                          "label": "Except pursuant to and in compliance with § 164.508(a)(4), a covered entity or business associate may not sell protected health information."
                         },
                         {
                           "ref": "164.502(a)(5)(ii)(B)",
                           "label": "For purposes of this paragraph, sale of protected health information means:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.502(a)(5)(ii)(B)(1)",
-                              "label": "Except as provided in [paragraph (a)(5)(ii)(B)(](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(ii)(B)(2))[*2*](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(ii)(B)(2))[)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(ii)(B)(2)) of this section, a disclosure of protected health information by a covered entity or business associate, if applicable, where the covered entity or business associate directly or indirectly receives remuneration from or on behalf of the recipient of the protected health information in exchange for the protected health information"
+                              "label": "Except as provided in paragraph (a)(5)(ii)(B)(2) of this section, a disclosure of protected health information by a covered entity or business associate, if applicable, where the covered entity or business associate directly or indirectly receives remuneration from or on behalf of the recipient of the protected health information in exchange for the protected health information"
                             },
                             {
                               "ref": "164.502(a)(5)(ii)(B)(2)",
                               "label": "Sale of protected health information does not include a disclosure of protected health information:",
+                              "group": true,
                               "controls": [
                                 {
                                   "ref": "164.502(a)(5)(ii)(B)(2)(i)",
-                                  "label": "For public health purposes pursuant to [§ 164.512(b)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(b)) or [§ 164.514(e)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e));"
+                                  "label": "For public health purposes pursuant to § 164.512(b) or § 164.514(e);"
                                 },
                                 {
                                   "ref": "164.502(a)(5)(ii)(B)(2)(ii)",
-                                  "label": "For research purposes pursuant to [§ 164.512(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)) or [§ 164.514(e)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)), where the only remuneration received by the covered entity or business associate is a reasonable cost-based fee to cover the cost to prepare and transmit the protected health information for such purposes;"
+                                  "label": "For research purposes pursuant to § 164.512(i) or § 164.514(e), where the only remuneration received by the covered entity or business associate is a reasonable cost-based fee to cover the cost to prepare and transmit the protected health information for such purposes;"
                                 },
                                 {
                                   "ref": "164.502(a)(5)(ii)(B)(2)(iii)",
-                                  "label": "For treatment and payment purposes pursuant to [§ 164.506(a)](https://www.ecfr.gov/current/title-45/section-164.506#p-164.506(a));"
+                                  "label": "For treatment and payment purposes pursuant to § 164.506(a);"
                                 },
                                 {
                                   "ref": "164.502(a)(5)(ii)(B)(2)(iv)",
-                                  "label": "For the sale, transfer, merger, or consolidation of all or part of the covered entity and for related due diligence as described in paragraph (6)(iv) of the definition of health care operations and pursuant to [§ 164.506(a)](https://www.ecfr.gov/current/title-45/section-164.506#p-164.506(a));"
+                                  "label": "For the sale, transfer, merger, or consolidation of all or part of the covered entity and for related due diligence as described in paragraph (6)(iv) of the definition of health care operations and pursuant to § 164.506(a);"
                                 },
                                 {
                                   "ref": "164.502(a)(5)(ii)(B)(2)(v)",
-                                  "label": "To or by a business associate for activities that the business associate undertakes on behalf of a covered entity, or on behalf of a business associate in the case of a subcontractor, pursuant to [§§ 164.502(e)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(e)) and [164.504(e)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)), and the only remuneration provided is by the covered entity to the business associate, or by the business associate to the subcontractor, if applicable, for the performance of such activities;"
+                                  "label": "To or by a business associate for activities that the business associate undertakes on behalf of a covered entity, or on behalf of a business associate in the case of a subcontractor, pursuant to §§ 164.502(e) and 164.504(e), and the only remuneration provided is by the covered entity to the business associate, or by the business associate to the subcontractor, if applicable, for the performance of such activities;"
                                 },
                                 {
                                   "ref": "164.502(a)(5)(ii)(B)(2)(vi)",
-                                  "label": "To an individual, when requested under [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524) or [§ 164.528](https://www.ecfr.gov/current/title-45/section-164.528);"
+                                  "label": "To an individual, when requested under § 164.524 or § 164.528;"
                                 },
                                 {
                                   "ref": "164.502(a)(5)(ii)(B)(2)(vii)",
-                                  "label": "Required by law as permitted under [§ 164.512(a)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(a)); and"
+                                  "label": "Required by law as permitted under § 164.512(a); and"
                                 },
                                 {
                                   "ref": "164.502(a)(5)(ii)(B)(2)(viii)",
@@ -441,11 +470,13 @@
                     {
                       "ref": "164.502(a)(5)(iii)",
                       "label": "Reproductive health care",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.502(a)(5)(iii)(A)",
                           "label": "Prohibition",
-                          "description": "Subject to [paragraphs (a)(5)(iii)(B)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(B)) and [(C)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(C)) of this section, a covered entity or business associate may not use or disclose protected health information for any of the following activities:",
+                          "description": "Subject to paragraphs (a)(5)(iii)(B) and (C) of this section, a covered entity or business associate may not use or disclose protected health information for any of the following activities:",
+                          "group": false,
                           "controls": [
                             {
                               "ref": "164.502(a)(5)(iii)(A)(1)",
@@ -457,14 +488,15 @@
                             },
                             {
                               "ref": "164.502(a)(5)(iii)(A)(3)",
-                              "label": "To identify any person for any purpose described in [paragraphs (a)(5)(iii)(A)(](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(A)(1))[*1*](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(A)(1))[)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(A)(1)) or [(](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(A)(2))[*2*](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(A)(2))[)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(A)(2)) of this section."
+                              "label": "To identify any person for any purpose described in paragraphs (a)(5)(iii)(A)(1) or (2) of this section."
                             }
                           ]
                         },
                         {
                           "ref": "164.502(a)(5)(iii)(B)",
-                          "label": "***Rule of applicability.***",
-                          "description": "The prohibition at [paragraph (a)(5)(iii)(A)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(A)) of this section applies only where the relevant activity is in connection with any person seeking, obtaining, providing, or facilitating reproductive health care, and the covered entity or business associate that received the request for protected health information has reasonably determined that one or more of the following conditions exists:",
+                          "label": "Rule of applicability.",
+                          "description": "The prohibition at paragraph (a)(5)(iii)(A) of this section applies only where the relevant activity is in connection with any person seeking, obtaining, providing, or facilitating reproductive health care, and the covered entity or business associate that received the request for protected health information has reasonably determined that one or more of the following conditions exists:",
+                          "group": false,
                           "controls": [
                             {
                               "ref": "164.502(a)(5)(iii)(B)(1)",
@@ -476,14 +508,15 @@
                             },
                             {
                               "ref": "164.502(a)(5)(iii)(B)(3)",
-                              "label": "The presumption at [paragraph (a)(5)(iii)(C)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(C)) of this section applies."
+                              "label": "The presumption at paragraph (a)(5)(iii)(C) of this section applies."
                             }
                           ]
                         },
                         {
                           "ref": "164.502(a)(5)(iii)(C)",
-                          "label": "***Presumption.***",
-                          "description": "The reproductive health care provided by another person is presumed lawful under [paragraph (a)(5)(iii)(B)(](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(B)(1))[*1*](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(B)(1))[)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(B)(1)) or [(](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(B)(2))[*2*](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(B)(2))[)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(B)(2)) of this section unless the covered entity or business associate has any of the following:",
+                          "label": "Presumption.",
+                          "description": "The reproductive health care provided by another person is presumed lawful under paragraph (a)(5)(iii)(B)(1) or (2) of this section unless the covered entity or business associate has any of the following:",
+                          "group": false,
                           "controls": [
                             {
                               "ref": "164.502(a)(5)(iii)(C)(1)",
@@ -508,13 +541,15 @@
             },
             {
               "ref": "164.502(b)",
-              "label": "**Standard: Minimum necessary**",
+              "label": "Standard: Minimum necessary",
               "description": "Minimum necessary applies. When using or disclosing protected health information or when requesting protected health information from another covered entity or business associate, a covered entity or business associate must make reasonable efforts to limit protected health information to the minimum necessary to accomplish the intended purpose of the use, disclosure, or request.",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.502(b)(2)",
                   "label": "Minimum necessary does not apply.",
                   "description": "This requirement does not apply to:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.502(b)(2)(i)",
@@ -522,11 +557,11 @@
                     },
                     {
                       "ref": "164.502(b)(2)(ii)",
-                      "label": "Uses or disclosures made to the individual, as permitted under [paragraph (a)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(1)(i)) of this section or as required by [paragraph (a)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(2)(i)) of this section;"
+                      "label": "Uses or disclosures made to the individual, as permitted under paragraph (a)(1)(i) of this section or as required by paragraph (a)(2)(i) of this section;"
                     },
                     {
                       "ref": "164.502(b)(2)(iii)",
-                      "label": "Uses or disclosures made pursuant to an authorization under [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508);"
+                      "label": "Uses or disclosures made pursuant to an authorization under § 164.508;"
                     },
                     {
                       "ref": "164.502(b)(2)(iv)",
@@ -534,7 +569,7 @@
                     },
                     {
                       "ref": "164.502(b)(2)(v)",
-                      "label": "Uses or disclosures that are required by law, as described by [§ 164.512(a)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(a)); and"
+                      "label": "Uses or disclosures that are required by law, as described by § 164.512(a); and"
                     },
                     {
                       "ref": "164.502(b)(2)(vi)",
@@ -547,11 +582,12 @@
             {
               "ref": "164.502(c)",
               "label": "Standard: Uses and disclosures of protected health information subject to an agreed upon restriction",
-              "description": "A covered entity that has agreed to a restriction pursuant to [§ 164.522(a)(1)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a)(1)) may not use or disclose the protected health information covered by the restriction in violation of such restriction, except as otherwise provided in [§ 164.522(a)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a))."
+              "description": "A covered entity that has agreed to a restriction pursuant to § 164.522(a)(1) may not use or disclose the protected health information covered by the restriction in violation of such restriction, except as otherwise provided in § 164.522(a)."
             },
             {
               "ref": "164.502(d)",
               "label": "Standard: Uses and disclosures of de-identified protected health information",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.502(d)(1)",
@@ -561,7 +597,8 @@
                 {
                   "ref": "164.502(d)(2)",
                   "label": "Uses and disclosures of de-identified information",
-                  "description": "Health information that meets the standard and implementation specifications for de-identification under [§ 164.514(a)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(a)) and [(b)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(b)) is considered not to be individually identifiable health information, *i.e.,* de-identified. The requirements of this subpart do not apply to information that has been de-identified in accordance with the applicable requirements of [§ 164.514](https://www.ecfr.gov/current/title-45/section-164.514), provided that:",
+                  "description": "Health information that meets the standard and implementation specifications for de-identification under § 164.514(a) and (b) is considered not to be individually identifiable health information, i.e., de-identified. The requirements of this subpart do not apply to information that has been de-identified in accordance with the applicable requirements of § 164.514, provided that:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.502(d)(2)(i)",
@@ -577,10 +614,12 @@
             },
             {
               "ref": "164.502(e)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.502(e)(1)",
                   "label": "Standard: Disclosures to business associates",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.502(e)(1)(i)",
@@ -588,29 +627,30 @@
                     },
                     {
                       "ref": "164.502(e)(1)(ii)",
-                      "label": "A business associate may disclose protected health information to a business associate that is a subcontractor and may allow the subcontractor to create, receive, maintain, or transmit protected health information on its behalf, if the business associate obtains satisfactory assurances, in accordance with [§ 164.504(e)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(1)(i)), that the subcontractor will appropriately safeguard the information."
+                      "label": "A business associate may disclose protected health information to a business associate that is a subcontractor and may allow the subcontractor to create, receive, maintain, or transmit protected health information on its behalf, if the business associate obtains satisfactory assurances, in accordance with § 164.504(e)(1)(i), that the subcontractor will appropriately safeguard the information."
                     }
                   ]
                 },
                 {
                   "ref": "164.502(e)(2)",
                   "label": "Implementation specification: Documentation.",
-                  "description": "The satisfactory assurances required by [paragraph (e)(1)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(e)(1)) of this section must be documented through a written contract or other written agreement or arrangement with the business associate that meets the applicable requirements of [§ 164.504(e)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e))."
+                  "description": "The satisfactory assurances required by paragraph (e)(1) of this section must be documented through a written contract or other written agreement or arrangement with the business associate that meets the applicable requirements of § 164.504(e)."
                 }
               ]
             },
             {
               "ref": "164.502(f)",
-              "label": "**Standard: Deceased individuals.**",
+              "label": "Standard: Deceased individuals.",
               "description": "A covered entity must comply with the requirements of this subpart with respect to the protected health information of a deceased individual for a period of 50 years following the death of the individual."
             },
             {
               "ref": "164.502(g)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.502(g)(1)",
                   "label": "Standard: Personal representatives",
-                  "description": "As specified in this paragraph, a covered entity must, except as provided in [paragraphs (g)(3)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(3)) and [(g)(5)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(5)) of this section, treat a personal representative as the individual for purposes of this subchapter."
+                  "description": "As specified in this paragraph, a covered entity must, except as provided in paragraphs (g)(3) and (g)(5) of this section, treat a personal representative as the individual for purposes of this subchapter."
                 },
                 {
                   "ref": "164.502(g)(2)",
@@ -619,11 +659,13 @@
                 },
                 {
                   "ref": "164.502(g)(3)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.502(g)(3)(i)",
                       "label": "Implementation specification: Unemancipated minors",
-                      "description": "If under applicable law a parent, guardian, or other person acting *in loco parentis* has authority to act on behalf of an individual who is an unemancipated minor in making decisions related to health care, a covered entity must treat such person as a personal representative under this subchapter, with respect to protected health information relevant to such personal representation, except that such person may not be a personal representative of an unemancipated minor, and the minor has the authority to act as an individual, with respect to protected health information pertaining to a health care service, if:",
+                      "description": "If under applicable law a parent, guardian, or other person acting in loco parentis has authority to act on behalf of an individual who is an unemancipated minor in making decisions related to health care, a covered entity must treat such person as a personal representative under this subchapter, with respect to protected health information relevant to such personal representation, except that such person may not be a personal representative of an unemancipated minor, and the minor has the authority to act as an individual, with respect to protected health information pertaining to a health care service, if:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.502(g)(3)(i)(A)",
@@ -631,29 +673,30 @@
                         },
                         {
                           "ref": "164.502(g)(3)(i)(B)",
-                          "label": "The minor may lawfully obtain such health care service without the consent of a parent, guardian, or other person acting *in loco parentis,* and the minor, a court, or another person authorized by law consents to such health care service; or"
+                          "label": "The minor may lawfully obtain such health care service without the consent of a parent, guardian, or other person acting in loco parentis, and the minor, a court, or another person authorized by law consents to such health care service; or"
                         },
                         {
                           "ref": "164.502(g)(3)(i)(C)",
-                          "label": "A parent, guardian, or other person acting *in loco parentis* assents to an agreement of confidentiality between a covered health care provider and the minor with respect to such health care service."
+                          "label": "A parent, guardian, or other person acting in loco parentis assents to an agreement of confidentiality between a covered health care provider and the minor with respect to such health care service."
                         }
                       ]
                     },
                     {
                       "ref": "164.502(g)(3)(ii)",
-                      "label": "Notwithstanding the provisions of [paragraph (g)(3)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(3)(i)) of this section:",
+                      "label": "Notwithstanding the provisions of paragraph (g)(3)(i) of this section:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.502(g)(3)(ii)(A)",
-                          "label": "If, and to the extent, permitted or required by an applicable provision of State or other law, including applicable case law, a covered entity may disclose, or provide access in accordance with [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524) to, protected health information about an unemancipated minor to a parent, guardian, or other person acting *in loco parentis*"
+                          "label": "If, and to the extent, permitted or required by an applicable provision of State or other law, including applicable case law, a covered entity may disclose, or provide access in accordance with § 164.524 to, protected health information about an unemancipated minor to a parent, guardian, or other person acting in loco parentis"
                         },
                         {
                           "ref": "164.502(g)(3)(ii)(B)",
-                          "label": "If, and to the extent, prohibited by an applicable provision of State or other law, including applicable case law, a covered entity may not disclose, or provide access in accordance with [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524) to, protected health information about an unemancipated minor to a parent, guardian, or other person acting *in loco parentis*; and"
+                          "label": "If, and to the extent, prohibited by an applicable provision of State or other law, including applicable case law, a covered entity may not disclose, or provide access in accordance with § 164.524 to, protected health information about an unemancipated minor to a parent, guardian, or other person acting in loco parentis; and"
                         },
                         {
                           "ref": "164.502(g)(3)(ii)(C)",
-                          "label": "Where the parent, guardian, or other person acting *in loco parentis,* is not the personal representative under [paragraphs (g)(3)(i)(A)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(3)(i)(A)), [(B)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(3)(i)(B)), or [(C)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(3)(i)(C)) of this section and where there is no applicable access provision under State or other law, including case law, a covered entity may provide or deny access under [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524) to a parent, guardian, or other person acting *in loco parentis,* if such action is consistent with State or other applicable law, provided that such decision must be made by a licensed health care professional, in the exercise of professional judgment."
+                          "label": "Where the parent, guardian, or other person acting in loco parentis, is not the personal representative under paragraphs (g)(3)(i)(A), (B), or (C) of this section and where there is no applicable access provision under State or other law, including case law, a covered entity may provide or deny access under § 164.524 to a parent, guardian, or other person acting in loco parentis, if such action is consistent with State or other applicable law, provided that such decision must be made by a licensed health care professional, in the exercise of professional judgment."
                         }
                       ]
                     }
@@ -667,15 +710,18 @@
                 {
                   "ref": "164.502(g)(5)",
                   "label": "Implementation specification: Abuse, neglect, endangerment situations.",
-                  "description": "Notwithstanding a State law or any requirement of this paragraph to the contrary, a covered entity may elect not to treat a person as the personal representative, provided that the conditions at [paragraphs (g)(5)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(5)(i)) and [(ii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(5)(ii)) of this section are met:",
+                  "description": "Notwithstanding a State law or any requirement of this paragraph to the contrary, a covered entity may elect not to treat a person as the personal representative, provided that the conditions at paragraphs (g)(5)(i) and (ii) of this section are met:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.502(g)(5)(i)",
-                      "label": "[Paragraphs (g)(5)(i)(A)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(5)(i)(A)) and [(B)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(5)(i)(B)) of this section both apply.",
+                      "label": "Paragraphs (g)(5)(i)(A) and (B) of this section both apply.",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.502(g)(5)(i)(A)",
                           "label": "The covered entity has a reasonable belief that any of the following is true:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.502(g)(5)(i)(A)(1)",
@@ -695,7 +741,7 @@
                     },
                     {
                       "ref": "164.502(g)(5)(ii)",
-                      "label": "The covered entity does not have a reasonable belief under [paragraph (g)(5)(i)(A)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(g)(5)(i)(A)) of this section if the basis for their belief is the provision or facilitation of reproductive health care by such person for and at the request of the individual."
+                      "label": "The covered entity does not have a reasonable belief under paragraph (g)(5)(i)(A) of this section if the basis for their belief is the provision or facilitation of reproductive health care by such person for and at the request of the individual."
                     }
                   ]
                 }
@@ -704,21 +750,23 @@
             {
               "ref": "164.502(h)",
               "label": "Standard: Confidential communications.",
-              "description": "A covered health care provider or health plan must comply with the applicable requirements of [§ 164.522(b)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(b)) in communicating protected health information."
+              "description": "A covered health care provider or health plan must comply with the applicable requirements of § 164.522(b) in communicating protected health information."
             },
             {
               "ref": "164.502(i)",
               "label": "Standard: Uses and disclosures consistent with notice.",
-              "description": "A covered entity that is required by [§ 164.520](https://www.ecfr.gov/current/title-45/section-164.520) to have a notice may not use or disclose protected health information in a manner inconsistent with such notice. A covered entity that is required by [§ 164.520(b)(1)(iii)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(iii)) to include a specific statement in its notice if it intends to engage in an activity listed in [§ 164.520(b)(1)(iii)(A)-(C)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(iii)(A)), may not use or disclose protected health information for such activities, unless the required statement is included in the notice."
+              "description": "A covered entity that is required by § 164.520 to have a notice may not use or disclose protected health information in a manner inconsistent with such notice. A covered entity that is required by § 164.520(b)(1)(iii) to include a specific statement in its notice if it intends to engage in an activity listed in § 164.520(b)(1)(iii)(A)-(C), may not use or disclose protected health information for such activities, unless the required statement is included in the notice."
             },
             {
               "ref": "164.502(j)",
-              "label": "**Standard: Disclosures by whistleblowers and workforce member crime victims**",
+              "label": "Standard: Disclosures by whistleblowers and workforce member crime victims",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.502(j)(1)",
                   "label": "Disclosures by whistleblowers",
                   "description": "A covered entity is not considered to have violated the requirements of this subpart if a member of its workforce or a business associate discloses protected health information, provided that:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.502(j)(1)(i)",
@@ -727,6 +775,7 @@
                     {
                       "ref": "164.502(j)(1)(ii)",
                       "label": "The disclosure is to:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.502(j)(1)(ii)(A)",
@@ -734,7 +783,7 @@
                         },
                         {
                           "ref": "164.502(j)(1)(ii)(B)",
-                          "label": "An attorney retained by or on behalf of the workforce member or business associate for the purpose of determining the legal options of the workforce member or business associate with regard to the conduct described in [paragraph (j)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(j)(1)(i)) of this section."
+                          "label": "An attorney retained by or on behalf of the workforce member or business associate for the purpose of determining the legal options of the workforce member or business associate with regard to the conduct described in paragraph (j)(1)(i) of this section."
                         }
                       ]
                     }
@@ -744,6 +793,7 @@
                   "ref": "164.502(j)(2)",
                   "label": "Disclosures by workforce members who are victims of a crime",
                   "description": "A covered entity is not considered to have violated the requirements of this subpart if a member of its workforce who is the victim of a criminal act discloses protected health information to a law enforcement official, provided that:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.502(j)(2)(i)",
@@ -751,7 +801,7 @@
                     },
                     {
                       "ref": "164.502(j)(2)(ii)",
-                      "label": "The protected health information disclosed is limited to the information listed in [§ 164.512(f)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(2)(i))."
+                      "label": "The protected health information disclosed is limited to the information listed in § 164.512(f)(2)(i)."
                     }
                   ]
                 }
@@ -762,25 +812,28 @@
         {
           "ref": "164.504",
           "label": "Uses and disclosures: Organizational requirements.",
+          "group": true,
           "controls": [
             {
               "ref": "164.504(e)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.504(e)(1)",
                   "label": "Standard: Business associate contracts.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.504(e)(1)(i)",
-                      "label": "The contract or other arrangement required by [§ 164.502(e)(2)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(e)(2)) must meet the requirements of [paragraph (e)(2)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(2)), [(e)(3)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(3)), or [(e)(5)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(5)) of this section, as applicable"
+                      "label": "The contract or other arrangement required by § 164.502(e)(2) must meet the requirements of paragraph (e)(2), (e)(3), or (e)(5) of this section, as applicable"
                     },
                     {
                       "ref": "164.504(e)(1)(ii)",
-                      "label": "A covered entity is not in compliance with the standards in [§ 164.502(e)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(e)) and this paragraph, if the covered entity knew of a pattern of activity or practice of the business associate that constituted a material breach or violation of the business associate's obligation under the contract or other arrangement, unless the covered entity took reasonable steps to cure the breach or end the violation, as applicable, and, if such steps were unsuccessful, terminated the contract or arrangement, if feasible."
+                      "label": "A covered entity is not in compliance with the standards in § 164.502(e) and this paragraph, if the covered entity knew of a pattern of activity or practice of the business associate that constituted a material breach or violation of the business associate's obligation under the contract or other arrangement, unless the covered entity took reasonable steps to cure the breach or end the violation, as applicable, and, if such steps were unsuccessful, terminated the contract or arrangement, if feasible."
                     },
                     {
                       "ref": "164.504(e)(1)(iii)",
-                      "label": "A business associate is not in compliance with the standards in [§ 164.502(e)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(e)) and this paragraph, if the business associate knew of a pattern of activity or practice of a subcontractor that constituted a material breach or violation of the subcontractor's obligation under the contract or other arrangement, unless the business associate took reasonable steps to cure the breach or end the violation, as applicable, and, if such steps were unsuccessful, terminated the contract or arrangement, if feasible."
+                      "label": "A business associate is not in compliance with the standards in § 164.502(e) and this paragraph, if the business associate knew of a pattern of activity or practice of a subcontractor that constituted a material breach or violation of the subcontractor's obligation under the contract or other arrangement, unless the business associate took reasonable steps to cure the breach or end the violation, as applicable, and, if such steps were unsuccessful, terminated the contract or arrangement, if feasible."
                     }
                   ]
                 },
@@ -788,14 +841,16 @@
                   "ref": "164.504(e)(2)",
                   "label": "Implementation specifications: Business associate contracts",
                   "description": "A contract between the covered entity and a business associate must:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.504(e)(2)(i)",
                       "label": "Establish the permitted and required uses and disclosures of protected health information by the business associate. The contract may not authorize the business associate to use or further disclose the information in a manner that would violate the requirements of this subpart, if done by the covered entity, except that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.504(e)(2)(i)(A)",
-                          "label": "The contract may permit the business associate to use and disclose protected health information for the proper management and administration of the business associate, as provided in [paragraph (e)(4)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(4)) of this section; and"
+                          "label": "The contract may permit the business associate to use and disclose protected health information for the proper management and administration of the business associate, as provided in paragraph (e)(4) of this section; and"
                         },
                         {
                           "ref": "164.504(e)(2)(i)(B)",
@@ -806,6 +861,7 @@
                     {
                       "ref": "164.504(e)(2)(ii)",
                       "label": "Provide that the business associate will:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.504(e)(2)(ii)(A)",
@@ -813,27 +869,27 @@
                         },
                         {
                           "ref": "164.504(e)(2)(ii)(B)",
-                          "label": "Use appropriate safeguards and comply, where applicable, with [subpart C of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-C) with respect to electronic protected health information, to prevent use or disclosure of the information other than as provided for by its contract;"
+                          "label": "Use appropriate safeguards and comply, where applicable, with subpart C of this part with respect to electronic protected health information, to prevent use or disclosure of the information other than as provided for by its contract;"
                         },
                         {
                           "ref": "164.504(e)(2)(ii)(C)",
-                          "label": "Report to the covered entity any use or disclosure of the information not provided for by its contract of which it becomes aware, including breaches of unsecured protected health information as required by [§ 164.410](https://www.ecfr.gov/current/title-45/section-164.410);"
+                          "label": "Report to the covered entity any use or disclosure of the information not provided for by its contract of which it becomes aware, including breaches of unsecured protected health information as required by § 164.410;"
                         },
                         {
                           "ref": "164.504(e)(2)(ii)(D)",
-                          "label": "In accordance with [§ 164.502(e)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(e)(1)(ii)), ensure that any subcontractors that create, receive, maintain, or transmit protected health information on behalf of the business associate agree to the same restrictions and conditions that apply to the business associate with respect to such information;"
+                          "label": "In accordance with § 164.502(e)(1)(ii), ensure that any subcontractors that create, receive, maintain, or transmit protected health information on behalf of the business associate agree to the same restrictions and conditions that apply to the business associate with respect to such information;"
                         },
                         {
                           "ref": "164.504(e)(2)(ii)(E)",
-                          "label": "Make available protected health information in accordance with [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524);"
+                          "label": "Make available protected health information in accordance with § 164.524;"
                         },
                         {
                           "ref": "164.504(e)(2)(ii)(F)",
-                          "label": "Make available protected health information for amendment and incorporate any amendments to protected health information in accordance with [§ 164.526](https://www.ecfr.gov/current/title-45/section-164.526);"
+                          "label": "Make available protected health information for amendment and incorporate any amendments to protected health information in accordance with § 164.526;"
                         },
                         {
                           "ref": "164.504(e)(2)(ii)(G)",
-                          "label": "Make available the information required to provide an accounting of disclosures in accordance with [§ 164.528](https://www.ecfr.gov/current/title-45/section-164.528);"
+                          "label": "Make available the information required to provide an accounting of disclosures in accordance with § 164.528;"
                         },
                         {
                           "ref": "164.504(e)(2)(ii)(H)",
@@ -858,42 +914,46 @@
                 {
                   "ref": "164.504(e)(3)",
                   "label": "Implementation specifications: Other arrangements.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.504(e)(3)(i)",
                       "label": "If a covered entity and its business associate are both governmental entities:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.504(e)(3)(i)(A)",
-                          "label": "The covered entity may comply with this paragraph and [§ 164.314(a)(1)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(1)), if applicable, by entering into a memorandum of understanding with the business associate that contains terms that accomplish the objectives of [paragraph (e)(2)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(2)) of this section and [§ 164.314(a)(2)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(2)), if applicable."
+                          "label": "The covered entity may comply with this paragraph and § 164.314(a)(1), if applicable, by entering into a memorandum of understanding with the business associate that contains terms that accomplish the objectives of paragraph (e)(2) of this section and § 164.314(a)(2), if applicable."
                         },
                         {
                           "ref": "164.504(e)(3)(i)(B)",
-                          "label": "The covered entity may comply with this paragraph and [§ 164.314(a)(1)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(1)), if applicable, if other law (including regulations adopted by the covered entity or its business associate) contains requirements applicable to the business associate that accomplish the objectives of [paragraph (e)(2)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(2)) of this section and [§ 164.314(a)(2)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(2)), if applicable."
+                          "label": "The covered entity may comply with this paragraph and § 164.314(a)(1), if applicable, if other law (including regulations adopted by the covered entity or its business associate) contains requirements applicable to the business associate that accomplish the objectives of paragraph (e)(2) of this section and § 164.314(a)(2), if applicable."
                         }
                       ]
                     },
                     {
                       "ref": "164.504(e)(3)(ii)",
-                      "label": "If a business associate is required by law to perform a function or activity on behalf of a covered entity or to provide a service described in the definition of business associate in [§ 160.103 of this subchapter](https://www.ecfr.gov/current/title-45/section-160.103) to a covered entity, such covered entity may disclose protected health information to the business associate to the extent necessary to comply with the legal mandate without meeting the requirements of this paragraph and [§ 164.314(a)(1)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(1)), if applicable, provided that the covered entity attempts in good faith to obtain satisfactory assurances as required by [paragraph (e)(2)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(2)) of this section and [§ 164.314(a)(1)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(1)), if applicable, and, if such attempt fails, documents the attempt and the reasons that such assurances cannot be obtained."
+                      "label": "If a business associate is required by law to perform a function or activity on behalf of a covered entity or to provide a service described in the definition of business associate in § 160.103 of this subchapter to a covered entity, such covered entity may disclose protected health information to the business associate to the extent necessary to comply with the legal mandate without meeting the requirements of this paragraph and § 164.314(a)(1), if applicable, provided that the covered entity attempts in good faith to obtain satisfactory assurances as required by paragraph (e)(2) of this section and § 164.314(a)(1), if applicable, and, if such attempt fails, documents the attempt and the reasons that such assurances cannot be obtained."
                     },
                     {
                       "ref": "164.504(e)(3)(iii)",
-                      "label": "The covered entity may omit from its other arrangements the termination authorization required by [paragraph (e)(2)(iii)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(2)(iii)) of this section, if such authorization is inconsistent with the statutory obligations of the covered entity or its business associate."
+                      "label": "The covered entity may omit from its other arrangements the termination authorization required by paragraph (e)(2)(iii) of this section, if such authorization is inconsistent with the statutory obligations of the covered entity or its business associate."
                     },
                     {
                       "ref": "164.504(e)(3)(iv)",
-                      "label": "A covered entity may comply with this paragraph and [§ 164.314(a)(1)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(1)) if the covered entity discloses only a limited data set to a business associate for the business associate to carry out a health care operations function and the covered entity has a data use agreement with the business associate that complies with [§§ 164.514(e)(4)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)(4)) and [164.314(a)(1)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(1)), if applicable"
+                      "label": "A covered entity may comply with this paragraph and § 164.314(a)(1) if the covered entity discloses only a limited data set to a business associate for the business associate to carry out a health care operations function and the covered entity has a data use agreement with the business associate that complies with §§ 164.514(e)(4) and 164.314(a)(1), if applicable"
                     }
                   ]
                 },
                 {
                   "ref": "164.504(e)(4)",
                   "label": "Implementation specifications: Other requirements for contracts and other arrangements.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.504(e)(4)(i)",
                       "label": "The contract or other arrangement between the covered entity and the business associate may permit the business associate to use the protected health information received by the business associate in its capacity as a business associate to the covered entity, if necessary:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.504(e)(4)(i)(A)",
@@ -907,7 +967,8 @@
                     },
                     {
                       "ref": "164.504(e)(4)(ii)",
-                      "label": "The contract or other arrangement between the covered entity and the business associate may permit the business associate to disclose the protected health information received by the business associate in its capacity as a business associate for the purposes described in [paragraph (e)(4)(i)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(4)(i)) of this section, if:",
+                      "label": "The contract or other arrangement between the covered entity and the business associate may permit the business associate to disclose the protected health information received by the business associate in its capacity as a business associate for the purposes described in paragraph (e)(4)(i) of this section, if:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.504(e)(4)(ii)(A)",
@@ -915,6 +976,7 @@
                         },
                         {
                           "ref": "164.504(e)(4)(ii)(B)",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.504(e)(4)(ii)(B)(1)",
@@ -933,24 +995,27 @@
                 {
                   "ref": "164.504(e)(5)",
                   "label": "Implementation specifications: Business associate contracts with subcontractors",
-                  "description": "The requirements of [§ 164.504(e)(2)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(2)) through [(e)(4)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(4)) apply to the contract or other arrangement required by [§ 164.502(e)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(e)(1)(ii)) between a business associate and a business associate that is a subcontractor in the same manner as such requirements apply to contracts or other arrangements between a covered entity and business associate."
+                  "description": "The requirements of § 164.504(e)(2) through (e)(4) apply to the contract or other arrangement required by § 164.502(e)(1)(ii) between a business associate and a business associate that is a subcontractor in the same manner as such requirements apply to contracts or other arrangements between a covered entity and business associate."
                 }
               ]
             },
             {
               "ref": "164.504(f)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.504(f)(1)",
                   "label": "Standard: Requirements for group health plans.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.504(f)(1)(i)",
-                      "label": "Except as provided under [paragraph (f)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(1)(ii)) or [(iii)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(1)(iii)) of this section or as otherwise authorized under [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508), a group health plan, in order to disclose protected health information to the plan sponsor or to provide for or permit the disclosure of protected health information to the plan sponsor by a health insurance issuer or HMO with respect to the group health plan, must ensure that the plan documents restrict uses and disclosures of such information by the plan sponsor consistent with the requirements of this subpart."
+                      "label": "Except as provided under paragraph (f)(1)(ii) or (iii) of this section or as otherwise authorized under § 164.508, a group health plan, in order to disclose protected health information to the plan sponsor or to provide for or permit the disclosure of protected health information to the plan sponsor by a health insurance issuer or HMO with respect to the group health plan, must ensure that the plan documents restrict uses and disclosures of such information by the plan sponsor consistent with the requirements of this subpart."
                     },
                     {
                       "ref": "164.504(f)(1)(ii)",
-                      "label": "Except as prohibited by [§ 164.502(a)(5)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(i)), the group health plan, or a health insurance issuer or HMO with respect to the group health plan, may disclose summary health information to the plan sponsor, if the plan sponsor requests the summary health information for purposes of:",
+                      "label": "Except as prohibited by § 164.502(a)(5)(i), the group health plan, or a health insurance issuer or HMO with respect to the group health plan, may disclose summary health information to the plan sponsor, if the plan sponsor requests the summary health information for purposes of:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.504(f)(1)(ii)(A)",
@@ -970,8 +1035,9 @@
                 },
                 {
                   "ref": "164.504(f)(2)",
-                  "label": "**Implementation specifications: Requirements for plan documents.**",
+                  "label": "Implementation specifications: Requirements for plan documents.",
                   "description": "The plan documents of the group health plan must be amended to incorporate provisions to:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.504(f)(2)(i)",
@@ -980,6 +1046,7 @@
                     {
                       "ref": "164.504(f)(2)(ii)",
                       "label": "Provide that the group health plan will disclose protected health information to the plan sponsor only upon receipt of a certification by the plan sponsor that the plan documents have been amended to incorporate the following provisions and that the plan sponsor agrees to:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.504(f)(2)(ii)(A)",
@@ -999,15 +1066,15 @@
                         },
                         {
                           "ref": "164.504(f)(2)(ii)(E)",
-                          "label": "Make available protected health information in accordance with [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524);"
+                          "label": "Make available protected health information in accordance with § 164.524;"
                         },
                         {
                           "ref": "164.504(f)(2)(ii)(F)",
-                          "label": "Make available protected health information for amendment and incorporate any amendments to protected health information in accordance with [§ 164.526](https://www.ecfr.gov/current/title-45/section-164.526);"
+                          "label": "Make available protected health information for amendment and incorporate any amendments to protected health information in accordance with § 164.526;"
                         },
                         {
                           "ref": "164.504(f)(2)(ii)(G)",
-                          "label": "Make available the information required to provide an accounting of disclosures in accordance with [§ 164.528](https://www.ecfr.gov/current/title-45/section-164.528);"
+                          "label": "Make available the information required to provide an accounting of disclosures in accordance with § 164.528;"
                         },
                         {
                           "ref": "164.504(f)(2)(ii)(H)",
@@ -1019,13 +1086,14 @@
                         },
                         {
                           "ref": "164.504(f)(2)(ii)(J)",
-                          "label": "Ensure that the adequate separation required in [paragraph (f)(2)(iii)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(2)(iii)) of this section is established."
+                          "label": "Ensure that the adequate separation required in paragraph (f)(2)(iii) of this section is established."
                         }
                       ]
                     },
                     {
                       "ref": "164.504(f)(2)(iii)",
                       "label": "Provide for adequate separation between the group health plan and the plan sponsor. The plan documents must:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.504(f)(2)(iii)(A)",
@@ -1033,11 +1101,11 @@
                         },
                         {
                           "ref": "164.504(f)(2)(iii)(B)",
-                          "label": "Restrict the access to and use by such employees and other persons described in [paragraph (f)(2)(iii)(A)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(2)(iii)(A)) of this section to the plan administration functions that the plan sponsor performs for the group health plan; and"
+                          "label": "Restrict the access to and use by such employees and other persons described in paragraph (f)(2)(iii)(A) of this section to the plan administration functions that the plan sponsor performs for the group health plan; and"
                         },
                         {
                           "ref": "164.504(f)(2)(iii)(C)",
-                          "label": "Provide an effective mechanism for resolving any issues of noncompliance by persons described in [paragraph (f)(2)(iii)(A)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(2)(iii)(A)) of this section with the plan document provisions required by this paragraph."
+                          "label": "Provide an effective mechanism for resolving any issues of noncompliance by persons described in paragraph (f)(2)(iii)(A) of this section with the plan document provisions required by this paragraph."
                         }
                       ]
                     }
@@ -1047,10 +1115,11 @@
                   "ref": "164.504(f)(3)",
                   "label": "Implementation specifications: Uses and disclosures.",
                   "description": "A group health plan may:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.504(f)(3)(i)",
-                      "label": "Disclose protected health information to a plan sponsor to carry out plan administration functions that the plan sponsor performs only consistent with the provisions of [paragraph (f)(2)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(2)) of this section;"
+                      "label": "Disclose protected health information to a plan sponsor to carry out plan administration functions that the plan sponsor performs only consistent with the provisions of paragraph (f)(2) of this section;"
                     },
                     {
                       "ref": "164.504(f)(3)(ii)",
@@ -1058,7 +1127,7 @@
                     },
                     {
                       "ref": "164.504(f)(3)(iii)",
-                      "label": "Not disclose and may not permit a health insurance issuer or HMO to disclose protected health information to a plan sponsor as otherwise permitted by this paragraph unless a statement required by [§ 164.520(b)(1)(iii)(C)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(iii)(C)) is included in the appropriate notice; and"
+                      "label": "Not disclose and may not permit a health insurance issuer or HMO to disclose protected health information to a plan sponsor as otherwise permitted by this paragraph unless a statement required by § 164.520(b)(1)(iii)(C) is included in the appropriate notice; and"
                     },
                     {
                       "ref": "164.504(f)(3)(iv)",
@@ -1071,6 +1140,7 @@
             {
               "ref": "164.504(g)",
               "label": "Standard: Requirements for a covered entity with multiple covered functions.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.504(g)(1)",
@@ -1087,15 +1157,17 @@
         {
           "ref": "164.506",
           "label": "Uses and disclosures to carry out treatment, payment, or health care operations.",
+          "group": true,
           "controls": [
             {
               "ref": "164.506(a)",
               "label": "Standard: Permitted uses and disclosures.",
-              "description": "Except with respect to uses or disclosures that require an authorization under [§ 164.508(a)(2)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(a)(2)) through [(4)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(a)(4)) or that are prohibited under [§ 164.502(a)(5)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(i)), a covered entity may use or disclose protected health information for treatment, payment, or health care operations as set forth in [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.506#p-164.506(c)) of this section, provided that such use or disclosure is consistent with other applicable requirements of this subpart"
+              "description": "Except with respect to uses or disclosures that require an authorization under § 164.508(a)(2) through (4) or that are prohibited under § 164.502(a)(5)(i), a covered entity may use or disclose protected health information for treatment, payment, or health care operations as set forth in paragraph (c) of this section, provided that such use or disclosure is consistent with other applicable requirements of this subpart"
             },
             {
               "ref": "164.506(b)",
               "label": "Standard: Consent for uses and disclosures permitted.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.506(b)(1)",
@@ -1103,13 +1175,14 @@
                 },
                 {
                   "ref": "164.506(b)(2)",
-                  "label": "Consent, under [paragraph (b)](https://www.ecfr.gov/current/title-45/section-164.506#p-164.506(b)) of this section, shall not be effective to permit a use or disclosure of protected health information when an authorization, under [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508), is required or when another condition must be met for such use or disclosure to be permissible under this subpart."
+                  "label": "Consent, under paragraph (b) of this section, shall not be effective to permit a use or disclosure of protected health information when an authorization, under § 164.508, is required or when another condition must be met for such use or disclosure to be permissible under this subpart."
                 }
               ]
             },
             {
               "ref": "164.506(c)",
               "label": "Implementation specifications: Treatment, payment, or health care operations.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.506(c)(1)",
@@ -1126,6 +1199,7 @@
                 {
                   "ref": "164.506(c)(4)",
                   "label": "A covered entity may disclose protected health information to another covered entity for health care operations activities of the entity that receives the information, if each entity either has or had a relationship with the individual who is the subject of the protected health information being requested, the protected health information pertains to such relationship, and the disclosure is:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.506(c)(4)(i)",
@@ -1148,10 +1222,12 @@
         {
           "ref": "164.508",
           "label": "Uses and disclosures for which an authorization is required.",
+          "group": true,
           "controls": [
             {
               "ref": "164.508(a)",
-              "label": "**Standard: Authorizations for uses and disclosures**",
+              "label": "Standard: Authorizations for uses and disclosures",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.508(a)(1)",
@@ -1161,11 +1237,13 @@
                 {
                   "ref": "164.508(a)(2)",
                   "label": "Authorization required: Psychotherapy notes",
-                  "description": "Notwithstanding any provision of this subpart, other than the transition provisions in [§ 164.532](https://www.ecfr.gov/current/title-45/section-164.532), a covered entity must obtain an authorization for any use or disclosure of psychotherapy notes, except:",
+                  "description": "Notwithstanding any provision of this subpart, other than the transition provisions in § 164.532, a covered entity must obtain an authorization for any use or disclosure of psychotherapy notes, except:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.508(a)(2)(i)",
                       "label": "To carry out the following treatment, payment, or health care operations:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.508(a)(2)(i)(A)",
@@ -1183,17 +1261,19 @@
                     },
                     {
                       "ref": "164.508(a)(2)(ii)",
-                      "label": "A use or disclosure that is required by [§ 164.502(a)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(2)(ii)) or permitted by [§ 164.512(a)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(a)); [§ 164.512(d)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(d)) with respect to the oversight of the originator of the psychotherapy notes; [§ 164.512(g)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(g)(1)); or [§ 164.512(j)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(i))."
+                      "label": "A use or disclosure that is required by § 164.502(a)(2)(ii) or permitted by § 164.512(a); § 164.512(d) with respect to the oversight of the originator of the psychotherapy notes; § 164.512(g)(1); or § 164.512(j)(1)(i)."
                     }
                   ]
                 },
                 {
                   "ref": "164.508(a)(3)",
                   "label": "Authorization required: Marketing.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.508(a)(3)(i)",
-                      "label": "Notwithstanding any provision of this subpart, other than the transition provisions in [§ 164.532](https://www.ecfr.gov/current/title-45/section-164.532), a covered entity must obtain an authorization for any use or disclosure of protected health information for marketing, except if the communication is in the form of:",
+                      "label": "Notwithstanding any provision of this subpart, other than the transition provisions in § 164.532, a covered entity must obtain an authorization for any use or disclosure of protected health information for marketing, except if the communication is in the form of:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.508(a)(3)(i)(A)",
@@ -1207,17 +1287,18 @@
                     },
                     {
                       "ref": "164.508(a)(3)(ii)",
-                      "label": "If the marketing involves financial remuneration, as defined in paragraph (3) of the definition of marketing at [§ 164.501](https://www.ecfr.gov/current/title-45/section-164.501), to the covered entity from a third party, the authorization must state that such remuneration is involved."
+                      "label": "If the marketing involves financial remuneration, as defined in paragraph (3) of the definition of marketing at § 164.501, to the covered entity from a third party, the authorization must state that such remuneration is involved."
                     }
                   ]
                 },
                 {
                   "ref": "164.508(a)(4)",
                   "label": "Authorization required: Sale of protected health information.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.508(a)(4)(i)",
-                      "label": "Notwithstanding any provision of this subpart, other than the transition provisions in [§ 164.532](https://www.ecfr.gov/current/title-45/section-164.532), a covered entity must obtain an authorization for any disclosure of protected health information which is a sale of protected health information, as defined in [§ 164.501 of this subpart](https://www.ecfr.gov/current/title-45/part-164/section-164.501)."
+                      "label": "Notwithstanding any provision of this subpart, other than the transition provisions in § 164.532, a covered entity must obtain an authorization for any disclosure of protected health information which is a sale of protected health information, as defined in § 164.501 of this subpart."
                     },
                     {
                       "ref": "164.508(a)(4)(ii)",
@@ -1229,15 +1310,17 @@
             },
             {
               "ref": "164.508(b)",
-              "label": "**Implementation specifications: General requirements**",
+              "label": "Implementation specifications: General requirements",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.508(b)(1)",
                   "label": "Valid authorizations.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.508(b)(1)(i)",
-                      "label": "A valid authorization is a document that meets the requirements in [paragraphs (a)(3)(ii)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(a)(3)(ii)), [(a)(4)(ii)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(a)(4)(ii)), [(c)(1)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(c)(1)), and [(c)(2)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(c)(2)) of this section, as applicable."
+                      "label": "A valid authorization is a document that meets the requirements in paragraphs (a)(3)(ii), (a)(4)(ii), (c)(1), and (c)(2) of this section, as applicable."
                     },
                     {
                       "ref": "164.508(b)(1)(ii)",
@@ -1249,6 +1332,7 @@
                   "ref": "164.508(b)(2)",
                   "label": "Defective authorizations",
                   "description": "An authorization is not valid, if the document submitted has any of the following defects:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.508(b)(2)(i)",
@@ -1256,7 +1340,7 @@
                     },
                     {
                       "ref": "164.508(b)(2)(ii)",
-                      "label": "The authorization has not been filled out completely, with respect to an element described by [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(c)) of this section, if applicable;"
+                      "label": "The authorization has not been filled out completely, with respect to an element described by paragraph (c) of this section, if applicable;"
                     },
                     {
                       "ref": "164.508(b)(2)(iii)",
@@ -1264,7 +1348,7 @@
                     },
                     {
                       "ref": "164.508(b)(2)(iv)",
-                      "label": "The authorization violates [paragraph (b)(3)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(3)) or [(4)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(4)) of this section, if applicable;"
+                      "label": "The authorization violates paragraph (b)(3) or (4) of this section, if applicable;"
                     },
                     {
                       "ref": "164.508(b)(2)(v)",
@@ -1276,10 +1360,11 @@
                   "ref": "164.508(b)(3)",
                   "label": "Compound authorizations.",
                   "description": "An authorization for use or disclosure of protected health information may not be combined with any other document to create a compound authorization, except as follows:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.508(b)(3)(i)",
-                      "label": "An authorization for the use or disclosure of protected health information for a research study may be combined with any other type of written permission for the same or another research study. This exception includes combining an authorization for the use or disclosure of protected health information for a research study with another authorization for the same research study, with an authorization for the creation or maintenance of a research database or repository, or with a consent to participate in research. Where a covered health care provider has conditioned the provision of research-related treatment on the provision of one of the authorizations, as permitted under [paragraph (b)(4)(i)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(4)(i)) of this section, any compound authorization created under this paragraph must clearly differentiate between the conditioned and unconditioned components and provide the individual with an opportunity to opt in to the research activities described in the unconditioned authorization."
+                      "label": "An authorization for the use or disclosure of protected health information for a research study may be combined with any other type of written permission for the same or another research study. This exception includes combining an authorization for the use or disclosure of protected health information for a research study with another authorization for the same research study, with an authorization for the creation or maintenance of a research database or repository, or with a consent to participate in research. Where a covered health care provider has conditioned the provision of research-related treatment on the provision of one of the authorizations, as permitted under paragraph (b)(4)(i) of this section, any compound authorization created under this paragraph must clearly differentiate between the conditioned and unconditioned components and provide the individual with an opportunity to opt in to the research activities described in the unconditioned authorization."
                     },
                     {
                       "ref": "164.508(b)(3)(ii)",
@@ -1287,7 +1372,7 @@
                     },
                     {
                       "ref": "164.508(b)(3)(iii)",
-                      "label": "An authorization under this section, other than an authorization for a use or disclosure of psychotherapy notes, may be combined with any other such authorization under this section, except when a covered entity has conditioned the provision of treatment, payment, enrollment in the health plan, or eligibility for benefits under [paragraph (b)(4)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(4)) of this section on the provision of one of the authorizations. The prohibition in this paragraph on combining authorizations where one authorization conditions the provision of treatment, payment, enrollment in a health plan, or eligibility for benefits under [paragraph (b)(4)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(4)) of this section does not apply to a compound authorization created in accordance with [paragraph (b)(3)(i)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(3)(i)) of this section."
+                      "label": "An authorization under this section, other than an authorization for a use or disclosure of psychotherapy notes, may be combined with any other such authorization under this section, except when a covered entity has conditioned the provision of treatment, payment, enrollment in the health plan, or eligibility for benefits under paragraph (b)(4) of this section on the provision of one of the authorizations. The prohibition in this paragraph on combining authorizations where one authorization conditions the provision of treatment, payment, enrollment in a health plan, or eligibility for benefits under paragraph (b)(4) of this section does not apply to a compound authorization created in accordance with paragraph (b)(3)(i) of this section."
                     }
                   ]
                 },
@@ -1295,6 +1380,7 @@
                   "ref": "164.508(b)(4)",
                   "label": "Prohibition on conditioning of authorizations",
                   "description": "A covered entity may not condition the provision to an individual of treatment, payment, enrollment in the health plan, or eligibility for benefits on the provision of an authorization, except:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.508(b)(4)(i)",
@@ -1303,6 +1389,7 @@
                     {
                       "ref": "164.508(b)(4)(ii)",
                       "label": "A health plan may condition enrollment in the health plan or eligibility for benefits on provision of an authorization requested by the health plan prior to an individual's enrollment in the health plan, if:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.508(b)(4)(ii)(A)",
@@ -1310,7 +1397,7 @@
                         },
                         {
                           "ref": "164.508(b)(4)(ii)(B)",
-                          "label": "The authorization is not for a use or disclosure of psychotherapy notes under [paragraph (a)(2)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(a)(2)) of this section; and"
+                          "label": "The authorization is not for a use or disclosure of psychotherapy notes under paragraph (a)(2) of this section; and"
                         }
                       ]
                     },
@@ -1324,6 +1411,7 @@
                   "ref": "164.508(b)(5)",
                   "label": "Revocation of authorizations.",
                   "description": "An individual may revoke an authorization provided under this section at any time, provided that the revocation is in writing, except to the extent that:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.508(b)(5)(i)",
@@ -1338,18 +1426,20 @@
                 {
                   "ref": "164.508(b)(6)",
                   "label": "Documentation",
-                  "description": "A covered entity must document and retain any signed authorization under this section as required by [§ 164.530(j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j))."
+                  "description": "A covered entity must document and retain any signed authorization under this section as required by § 164.530(j)."
                 }
               ]
             },
             {
               "ref": "164.508(c)",
               "label": "Implementation specifications: Core elements and requirements",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.508(c)(1)",
                   "label": "Core elements",
                   "description": "A valid authorization under this section must contain at least the following elements:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.508(c)(1)(i)",
@@ -1381,10 +1471,12 @@
                   "ref": "164.508(c)(2)",
                   "label": "Required statements.",
                   "description": "In addition to the core elements, the authorization must contain statements adequate to place the individual on notice of all of the following:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.508(c)(2)(i)",
                       "label": "The individual's right to revoke the authorization in writing, and either:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.508(c)(2)(i)(A)",
@@ -1392,21 +1484,22 @@
                         },
                         {
                           "ref": "164.508(c)(2)(i)(B)",
-                          "label": "To the extent that the information in [paragraph (c)(2)(i)(A)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(c)(2)(i)(A)) of this section is included in the notice required by [§ 164.520](https://www.ecfr.gov/current/title-45/section-164.520), a reference to the covered entity's notice."
+                          "label": "To the extent that the information in paragraph (c)(2)(i)(A) of this section is included in the notice required by § 164.520, a reference to the covered entity's notice."
                         }
                       ]
                     },
                     {
                       "ref": "164.508(c)(2)(ii)",
                       "label": "The ability or inability to condition treatment, payment, enrollment or eligibility for benefits on the authorization, by stating either:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.508(c)(2)(ii)(A)",
-                          "label": "The covered entity may not condition treatment, payment, enrollment or eligibility for benefits on whether the individual signs the authorization when the prohibition on conditioning of authorizations in [paragraph (b)(4)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(4)) of this section applies; or"
+                          "label": "The covered entity may not condition treatment, payment, enrollment or eligibility for benefits on whether the individual signs the authorization when the prohibition on conditioning of authorizations in paragraph (b)(4) of this section applies; or"
                         },
                         {
                           "ref": "164.508(c)(2)(ii)(B)",
-                          "label": "The consequences to the individual of a refusal to sign the authorization when, in accordance with [paragraph (b)(4)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(4)) of this section, the covered entity can condition treatment, enrollment in the health plan, or eligibility for benefits on failure to obtain such authorization."
+                          "label": "The consequences to the individual of a refusal to sign the authorization when, in accordance with paragraph (b)(4) of this section, the covered entity can condition treatment, enrollment in the health plan, or eligibility for benefits on failure to obtain such authorization."
                         }
                       ]
                     },
@@ -1418,12 +1511,12 @@
                 },
                 {
                   "ref": "164.508(c)(3)",
-                  "label": "**Plain language requirement.**",
+                  "label": "Plain language requirement.",
                   "description": "The authorization must be written in plain language."
                 },
                 {
                   "ref": "164.508(c)(4)",
-                  "label": "**Copy to the individual.**",
+                  "label": "Copy to the individual.",
                   "description": "If a covered entity seeks an authorization from an individual for a use or disclosure of protected health information, the covered entity must provide the individual with a copy of the signed authorization."
                 }
               ]
@@ -1433,41 +1526,45 @@
         {
           "ref": "164.509",
           "label": "Uses and disclosures for which an attestation is required.",
+          "group": true,
           "controls": [
             {
               "ref": "164.509(a)",
               "label": "Standard:",
               "description": "Attestations for certain uses and disclosures of protected health information to persons other than covered entities or business associates.",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.509(a)(1)",
-                  "label": "A covered entity or business associate may not use or disclose protected health information potentially related to reproductive health care for purposes specified in [§ 164.512(d)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(d)), [(e)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)), [(f)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)), or [(g)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(g)(1)), without obtaining an attestation that is valid under [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(b)(1)) of this section from the person requesting the use or disclosure and complying with all applicable conditions of this part."
+                  "label": "A covered entity or business associate may not use or disclose protected health information potentially related to reproductive health care for purposes specified in § 164.512(d), (e), (f), or (g)(1), without obtaining an attestation that is valid under paragraph (b)(1) of this section from the person requesting the use or disclosure and complying with all applicable conditions of this part."
                 },
                 {
                   "ref": "164.509(a)(2)",
-                  "label": "A covered entity or business associate that uses or discloses protected health information potentially related to reproductive health care for purposes specified in [§ 164.512(d)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(d)), [(e)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)), [(f)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)), or [(g)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(g)(1)), in reliance on an attestation that is defective under [paragraph (b)(2)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(b)(2)) of this section, is not in compliance with this section."
+                  "label": "A covered entity or business associate that uses or discloses protected health information potentially related to reproductive health care for purposes specified in § 164.512(d), (e), (f), or (g)(1), in reliance on an attestation that is defective under paragraph (b)(2) of this section, is not in compliance with this section."
                 }
               ]
             },
             {
               "ref": "164.509(b)",
-              "label": "**Implementation specifications: General requirements**",
+              "label": "Implementation specifications: General requirements",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.509(b)(1)",
                   "label": "Valid attestations.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.509(b)(1)(i)",
-                      "label": "A valid attestation is a document that meets the requirements of [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(c)(1)) of this section."
+                      "label": "A valid attestation is a document that meets the requirements of paragraph (c)(1) of this section."
                     },
                     {
                       "ref": "164.509(b)(1)(ii)",
-                      "label": "A valid attestation verifies that the use or disclosure is not otherwise prohibited by [§ 164.502(a)(5)(iii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii))."
+                      "label": "A valid attestation verifies that the use or disclosure is not otherwise prohibited by § 164.502(a)(5)(iii)."
                     },
                     {
                       "ref": "164.509(b)(1)(iii)",
-                      "label": "A valid attestation may be electronic, provided that it meets the requirements in [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(c)(1)) of this section, as applicable."
+                      "label": "A valid attestation may be electronic, provided that it meets the requirements in paragraph (c)(1) of this section, as applicable."
                     }
                   ]
                 },
@@ -1475,18 +1572,19 @@
                   "ref": "164.509(b)(2)",
                   "label": "Defective attestations.",
                   "description": "An attestation is not valid if the document submitted has any of the following defects:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.509(b)(2)(i)",
-                      "label": "The attestation lacks an element or statement required by [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(c)) of this section."
+                      "label": "The attestation lacks an element or statement required by paragraph (c) of this section."
                     },
                     {
                       "ref": "164.509(b)(2)(ii)",
-                      "label": "The attestation contains an element or statement not required by [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(c)) of this section"
+                      "label": "The attestation contains an element or statement not required by paragraph (c) of this section"
                     },
                     {
                       "ref": "164.509(b)(2)(iii)",
-                      "label": "The attestation violates [paragraph (b)(3)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(b)(3)) of this section."
+                      "label": "The attestation violates paragraph (b)(3) of this section."
                     },
                     {
                       "ref": "164.509(b)(2)(iv)",
@@ -1494,25 +1592,27 @@
                     },
                     {
                       "ref": "164.509(b)(2)(v)",
-                      "label": "A reasonable covered entity or business associate in the same position would not believe that the attestation is true with respect to the requirement at [paragraph (c)(1)(iv)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(c)(1)(iv)) of this section."
+                      "label": "A reasonable covered entity or business associate in the same position would not believe that the attestation is true with respect to the requirement at paragraph (c)(1)(iv) of this section."
                     }
                   ]
                 },
                 {
                   "ref": "164.509(b)(3)",
                   "label": "Compound attestation.",
-                  "description": "An attestation may not be combined with any other document except where such other document is needed to satisfy the requirements at [paragraph (c)(iv)](https://www.ecfr.gov/current/title-45/section-164.509#p-164.509(c)(iv)) of this section or at [§ 164.502(a)(5)(iii)(C)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)(C)), as applicable."
+                  "description": "An attestation may not be combined with any other document except where such other document is needed to satisfy the requirements at paragraph (c)(iv) of this section or at § 164.502(a)(5)(iii)(C), as applicable."
                 }
               ]
             },
             {
               "ref": "164.509(c)",
               "label": "Implementation specifications: Content requirements and other obligations",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.509(c)(1)",
                   "label": "Required elements.",
                   "description": "A valid attestation under this section must contain the following elements:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.509(c)(1)(i)",
@@ -1528,11 +1628,11 @@
                     },
                     {
                       "ref": "164.509(c)(1)(iv)",
-                      "label": "A clear statement that the use or disclosure is not for a purpose prohibited under [§ 164.502(a)(5)(iii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii))."
+                      "label": "A clear statement that the use or disclosure is not for a purpose prohibited under § 164.502(a)(5)(iii)."
                     },
                     {
                       "ref": "164.509(c)(1)(v)",
-                      "label": "A statement that a person may be subject to criminal penalties pursuant to [42 U.S.C. 1320d-6](https://www.govinfo.gov/link/uscode/42/1320d-6) if that person knowingly and in violation of HIPAA obtains individually identifiable health information relating to an individual or discloses individually identifiable health information to another person."
+                      "label": "A statement that a person may be subject to criminal penalties pursuant to 42 U.S.C. 1320d-6 if that person knowingly and in violation of HIPAA obtains individually identifiable health information relating to an individual or discloses individually identifiable health information to another person."
                     },
                     {
                       "ref": "164.509(c)(1)(vi)",
@@ -1550,7 +1650,7 @@
             {
               "ref": "164.509(d)",
               "label": "Material misrepresentations.",
-              "description": "If, during the course of using or disclosing protected health information in reasonable reliance on a facially valid attestation, a covered entity or business associate discovers information reasonably showing that any representation made in the attestation was materially false, leading to a use or disclosure for a purpose prohibited under [§ 164.502(a)(5)(iii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)), the covered entity or business associate must cease such use or disclosure."
+              "description": "If, during the course of using or disclosing protected health information in reasonable reliance on a facially valid attestation, a covered entity or business associate discovers information reasonably showing that any representation made in the attestation was materially false, leading to a use or disclosure for a purpose prohibited under § 164.502(a)(5)(iii), the covered entity or business associate must cease such use or disclosure."
             }
           ]
         },
@@ -1558,19 +1658,23 @@
           "ref": "164.510",
           "label": "Uses and disclosures requiring an opportunity for the individual to agree or to object.",
           "description": "A covered entity may use or disclose protected health information, provided that the individual is informed in advance of the use or disclosure and has the opportunity to agree to or prohibit or restrict the use or disclosure, in accordance with the applicable requirements of this section. The covered entity may orally inform the individual of and obtain the individual's oral agreement or objection to a use or disclosure permitted by this section.",
+          "group": false,
           "controls": [
             {
               "ref": "164.510(a)",
               "label": "Standard: Use and disclosure for facility directories",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.510(a)(1)",
                   "label": "Permitted uses and disclosure",
-                  "description": "Except when an objection is expressed in accordance with [paragraphs (a)(2)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(a)(2)) or [(3)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(a)(3)) of this section, a covered health care provider may:",
+                  "description": "Except when an objection is expressed in accordance with paragraphs (a)(2) or (3) of this section, a covered health care provider may:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.510(a)(1)(i)",
                       "label": "Use the following protected health information to maintain a directory of individuals in its facility:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.510(a)(1)(i)(A)",
@@ -1593,6 +1697,7 @@
                     {
                       "ref": "164.510(a)(1)(ii)",
                       "label": "Use or disclose for directory purposes such information:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.510(a)(1)(ii)(A)",
@@ -1609,15 +1714,17 @@
                 {
                   "ref": "164.510(a)(2)",
                   "label": "Opportunity to object.",
-                  "description": "A covered health care provider must inform an individual of the protected health information that it may include in a directory and the persons to whom it may disclose such information (including disclosures to clergy of information regarding religious affiliation) and provide the individual with the opportunity to restrict or prohibit some or all of the uses or disclosures permitted by [paragraph (a)(1)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(a)(1)) of this section."
+                  "description": "A covered health care provider must inform an individual of the protected health information that it may include in a directory and the persons to whom it may disclose such information (including disclosures to clergy of information regarding religious affiliation) and provide the individual with the opportunity to restrict or prohibit some or all of the uses or disclosures permitted by paragraph (a)(1) of this section."
                 },
                 {
                   "ref": "164.510(a)(3)",
                   "label": "Emergency circumstances.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.510(a)(3)(i)",
-                      "label": "If the opportunity to object to uses or disclosures required by [paragraph (a)(2)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(a)(2)) of this section cannot practicably be provided because of the individual's incapacity or an emergency treatment circumstance, a covered health care provider may use or disclose some or all of the protected health information permitted by [paragraph (a)(1)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(a)(1)) of this section for the facility's directory, if such disclosure is:",
+                      "label": "If the opportunity to object to uses or disclosures required by paragraph (a)(2) of this section cannot practicably be provided because of the individual's incapacity or an emergency treatment circumstance, a covered health care provider may use or disclose some or all of the protected health information permitted by paragraph (a)(1) of this section for the facility's directory, if such disclosure is:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.510(a)(3)(i)(A)",
@@ -1631,7 +1738,7 @@
                     },
                     {
                       "ref": "164.510(a)(3)(ii)",
-                      "label": "The covered health care provider must inform the individual and provide an opportunity to object to uses or disclosures for directory purposes as required by [paragraph (a)(2)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(a)(2)) of this section when it becomes practicable to do so."
+                      "label": "The covered health care provider must inform the individual and provide an opportunity to object to uses or disclosures for directory purposes as required by paragraph (a)(2) of this section when it becomes practicable to do so."
                     }
                   ]
                 }
@@ -1640,25 +1747,28 @@
             {
               "ref": "164.510(b)",
               "label": "Standard: Uses and disclosures for involvement in the individual's care and notification purposes",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.510(b)(1)",
                   "label": "Permitted uses and disclosures.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.510(b)(1)(i)",
-                      "label": "A covered entity may, in accordance with [paragraphs (b)(2)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(2)), [(b)(3)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(3)), or [(b)(5)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(5)) of this section, disclose to a family member, other relative, or a close personal friend of the individual, or any other person identified by the individual, the protected health information directly relevant to such person's involvement with the individual's health care or payment related to the individual's health care."
+                      "label": "A covered entity may, in accordance with paragraphs (b)(2), (b)(3), or (b)(5) of this section, disclose to a family member, other relative, or a close personal friend of the individual, or any other person identified by the individual, the protected health information directly relevant to such person's involvement with the individual's health care or payment related to the individual's health care."
                     },
                     {
                       "ref": "164.510(b)(1)(ii)",
-                      "label": "A covered entity may use or disclose protected health information to notify, or assist in the notification of (including identifying or locating), a family member, a personal representative of the individual, or another person responsible for the care of the individual of the individual's location, general condition, or death. Any such use or disclosure of protected health information for such notification purposes must be in accordance with [paragraphs (b)(2)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(2)), [(b)(3)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(3)), [(b)(4)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(4)), or [(b)(5)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(5)) of this section, as applicable."
+                      "label": "A covered entity may use or disclose protected health information to notify, or assist in the notification of (including identifying or locating), a family member, a personal representative of the individual, or another person responsible for the care of the individual of the individual's location, general condition, or death. Any such use or disclosure of protected health information for such notification purposes must be in accordance with paragraphs (b)(2), (b)(3), (b)(4), or (b)(5) of this section, as applicable."
                     }
                   ]
                 },
                 {
                   "ref": "164.510(b)(2)",
                   "label": "Uses and disclosures with the individual present",
-                  "description": "If the individual is present for, or otherwise available prior to, a use or disclosure permitted by [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(1)) of this section and has the capacity to make health care decisions, the covered entity may use or disclose the protected health information if it:",
+                  "description": "If the individual is present for, or otherwise available prior to, a use or disclosure permitted by paragraph (b)(1) of this section and has the capacity to make health care decisions, the covered entity may use or disclose the protected health information if it:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.510(b)(2)(i)",
@@ -1682,12 +1792,12 @@
                 {
                   "ref": "164.510(b)(4)",
                   "label": "Uses and disclosures for disaster relief purposes",
-                  "description": "A covered entity may use or disclose protected health information to a public or private entity authorized by law or by its charter to assist in disaster relief efforts, for the purpose of coordinating with such entities the uses or disclosures permitted by [paragraph (b)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(1)(ii)) of this section. The requirements in [paragraphs (b)(2)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(2)), [(b)(3)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(3)), or [(b)(5)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(5)) of this section apply to such uses and disclosures to the extent that the covered entity, in the exercise of professional judgment, determines that the requirements do not interfere with the ability to respond to the emergency circumstances."
+                  "description": "A covered entity may use or disclose protected health information to a public or private entity authorized by law or by its charter to assist in disaster relief efforts, for the purpose of coordinating with such entities the uses or disclosures permitted by paragraph (b)(1)(ii) of this section. The requirements in paragraphs (b)(2), (b)(3), or (b)(5) of this section apply to such uses and disclosures to the extent that the covered entity, in the exercise of professional judgment, determines that the requirements do not interfere with the ability to respond to the emergency circumstances."
                 },
                 {
                   "ref": "164.510(b)(5)",
-                  "label": "**Uses and disclosures when the individual is deceased.**",
-                  "description": "If the individual is deceased, a covered entity may disclose to a family member, or other persons identified in [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b)(1)) of this section who were involved in the individual's care or payment for health care prior to the individual's death, protected health information of the individual that is relevant to such person's involvement, unless doing so is inconsistent with any prior expressed preference of the individual that is known to the covered entity."
+                  "label": "Uses and disclosures when the individual is deceased.",
+                  "description": "If the individual is deceased, a covered entity may disclose to a family member, or other persons identified in paragraph (b)(1) of this section who were involved in the individual's care or payment for health care prior to the individual's death, protected health information of the individual that is relevant to such person's involvement, unless doing so is inconsistent with any prior expressed preference of the individual that is known to the covered entity."
                 }
               ]
             }
@@ -1696,11 +1806,13 @@
         {
           "ref": "164.512",
           "label": "Uses and disclosures for which an authorization or opportunity to agree or object is not required.",
-          "description": "Except as provided by [§ 164.502(a)(5)(iii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)), a covered entity may use or disclose protected health information without the written authorization of the individual, as described in [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508), or the opportunity for the individual to agree or object as described in [§ 164.510](https://www.ecfr.gov/current/title-45/section-164.510), in the situations covered by this section, subject to the applicable requirements of this section and [§ 164.509](https://www.ecfr.gov/current/title-45/section-164.509). When the covered entity is required by this section to inform the individual of, or when the individual may agree to, a use or disclosure permitted by this section, the covered entity's information and the individual's agreement may be given verbally.",
+          "description": "Except as provided by § 164.502(a)(5)(iii), a covered entity may use or disclose protected health information without the written authorization of the individual, as described in § 164.508, or the opportunity for the individual to agree or object as described in § 164.510, in the situations covered by this section, subject to the applicable requirements of this section and § 164.509. When the covered entity is required by this section to inform the individual of, or when the individual may agree to, a use or disclosure permitted by this section, the covered entity's information and the individual's agreement may be given verbally.",
+          "group": false,
           "controls": [
             {
               "ref": "164.512(a)",
               "label": "Standard: Uses and disclosures required by law.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(a)(1)",
@@ -1708,18 +1820,20 @@
                 },
                 {
                   "ref": "164.512(a)(2)",
-                  "label": "A covered entity must meet the requirements described in [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(c)), [(e)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)), or [(f)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)) of this section for uses or disclosures required by law."
+                  "label": "A covered entity must meet the requirements described in paragraph (c), (e), or (f) of this section for uses or disclosures required by law."
                 }
               ]
             },
             {
               "ref": "164.512(b)",
               "label": "Standard: Uses and disclosures for public health activities",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(b)(1)",
                   "label": "Permitted uses and disclosures.",
                   "description": "A covered entity may use or disclose protected health information for the public health activities and purposes described in this paragraph to:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(b)(1)(i)",
@@ -1732,6 +1846,7 @@
                     {
                       "ref": "164.512(b)(1)(iii)",
                       "label": "A person subject to the jurisdiction of the Food and Drug Administration (FDA) with respect to an FDA-regulated product or activity for which that person has responsibility, for the purpose of activities related to the quality, safety or effectiveness of such FDA-regulated product or activity. Such purposes include:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(b)(1)(iii)(A)",
@@ -1758,10 +1873,12 @@
                     {
                       "ref": "164.512(b)(1)(v)",
                       "label": "An employer, about an individual who is a member of the workforce of the employer, if:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(b)(1)(v)(A)",
                           "label": "The covered entity is a covered health care provider who provides health care to the individual at the request of the employer:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.512(b)(1)(v)(A)(1)",
@@ -1779,11 +1896,12 @@
                         },
                         {
                           "ref": "164.512(b)(1)(v)(C)",
-                          "label": "The employer needs such findings in order to comply with its obligations, under [29 CFR parts 1904](https://www.ecfr.gov/current/title-29/part-1904) through [1928](https://www.ecfr.gov/current/title-29/part-1928), [30 CFR parts 50](https://www.ecfr.gov/current/title-30/part-50) through [90](https://www.ecfr.gov/current/title-30/part-90), or under state law having a similar purpose, to record such illness or injury or to carry out responsibilities for workplace medical surveillance; and"
+                          "label": "The employer needs such findings in order to comply with its obligations, under 29 CFR parts 1904 through 1928, 30 CFR parts 50 through 90, or under state law having a similar purpose, to record such illness or injury or to carry out responsibilities for workplace medical surveillance; and"
                         },
                         {
                           "ref": "164.512(b)(1)(v)(D)",
                           "label": "The covered health care provider provides written notice to the individual that protected health information relating to the medical surveillance of the workplace and work-related illnesses and injuries is disclosed to the employer:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.512(b)(1)(v)(D)(1)",
@@ -1800,6 +1918,7 @@
                     {
                       "ref": "164.512(b)(1)(vi)",
                       "label": "A school, about an individual who is a student or prospective student of the school, if:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(b)(1)(vi)(A)",
@@ -1812,10 +1931,11 @@
                         {
                           "ref": "164.512(b)(1)(vi)(C)",
                           "label": "The covered entity obtains and documents the agreement to the disclosure from either:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.512(b)(1)(vi)(C)(1)",
-                              "label": "A parent, guardian, or other person acting *in loco parentis* of the individual, if the individual is an unemancipated minor; or"
+                              "label": "A parent, guardian, or other person acting in loco parentis of the individual, if the individual is an unemancipated minor; or"
                             },
                             {
                               "ref": "164.512(b)(1)(vi)(C)(2)",
@@ -1830,18 +1950,20 @@
                 {
                   "ref": "164.512(b)(2)",
                   "label": "Permitted uses.",
-                  "description": "If the covered entity also is a public health authority, the covered entity is permitted to use protected health information in all cases in which it is permitted to disclose such information for public health activities under [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(b)(1)) of this section."
+                  "description": "If the covered entity also is a public health authority, the covered entity is permitted to use protected health information in all cases in which it is permitted to disclose such information for public health activities under paragraph (b)(1) of this section."
                 }
               ]
             },
             {
               "ref": "164.512(c)",
               "label": "Standard: Disclosures about victims of abuse, neglect, or domestic violence",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(c)(1)",
                   "label": "Permitted disclosures.",
-                  "description": "Except for reports of child abuse or neglect permitted by [paragraph (b)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(b)(1)(ii)) of this section, a covered entity may disclose protected health information about an individual whom the covered entity reasonably believes to be a victim of abuse, neglect, or domestic violence to a government authority, including a social service or protective services agency, authorized by law to receive reports of such abuse, neglect, or domestic violence:",
+                  "description": "Except for reports of child abuse or neglect permitted by paragraph (b)(1)(ii) of this section, a covered entity may disclose protected health information about an individual whom the covered entity reasonably believes to be a victim of abuse, neglect, or domestic violence to a government authority, including a social service or protective services agency, authorized by law to receive reports of such abuse, neglect, or domestic violence:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(c)(1)(i)",
@@ -1854,6 +1976,7 @@
                     {
                       "ref": "164.512(c)(1)(iii)",
                       "label": "To the extent the disclosure is expressly authorized by statute or regulation and:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(c)(1)(iii)(A)",
@@ -1870,7 +1993,8 @@
                 {
                   "ref": "164.512(c)(2)",
                   "label": "Informing the individual",
-                  "description": "A covered entity that makes a disclosure permitted by [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(c)(1)) of this section must promptly inform the individual that such a report has been or will be made, except if:",
+                  "description": "A covered entity that makes a disclosure permitted by paragraph (c)(1) of this section must promptly inform the individual that such a report has been or will be made, except if:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(c)(2)(i)",
@@ -1885,18 +2009,20 @@
                 {
                   "ref": "164.512(c)(3)",
                   "label": "Rule of construction",
-                  "description": "Nothing in this section shall be construed to permit disclosures prohibited by [§ 164.502(a)(5)(iii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)) when the sole basis of the report of abuse, neglect, or domestic violence is the provision or facilitation of reproductive health care."
+                  "description": "Nothing in this section shall be construed to permit disclosures prohibited by § 164.502(a)(5)(iii) when the sole basis of the report of abuse, neglect, or domestic violence is the provision or facilitation of reproductive health care."
                 }
               ]
             },
             {
               "ref": "164.512(d)",
               "label": "Standard: Uses and disclosures for health oversight activities",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(d)(1)",
-                  "label": "**Permitted disclosures.**",
+                  "label": "Permitted disclosures.",
                   "description": "A covered entity may disclose protected health information to a health oversight agency for oversight activities authorized by law, including audits; civil, administrative, or criminal investigations; inspections; licensure or disciplinary actions; civil, administrative, or criminal proceedings or actions; or other activities necessary for appropriate oversight of:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(d)(1)(i)",
@@ -1919,7 +2045,8 @@
                 {
                   "ref": "164.512(d)(2)",
                   "label": "Exception to health oversight activities.",
-                  "description": "For the purpose of the disclosures permitted by [paragraph (d)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(d)(1)) of this section, a health oversight activity does not include an investigation or other activity in which the individual is the subject of the investigation or activity and such investigation or other activity does not arise out of and is not directly related to:",
+                  "description": "For the purpose of the disclosures permitted by paragraph (d)(1) of this section, a health oversight activity does not include an investigation or other activity in which the individual is the subject of the investigation or activity and such investigation or other activity does not arise out of and is not directly related to:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(d)(2)(i)",
@@ -1938,23 +2065,25 @@
                 {
                   "ref": "164.512(d)(3)",
                   "label": "Joint activities or investigations.",
-                  "description": "Nothwithstanding [paragraph (d)(2)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(d)(2)) of this section, if a health oversight activity or investigation is conducted in conjunction with an oversight activity or investigation relating to a claim for public benefits not related to health, the joint activity or investigation is considered a health oversight activity for purposes of [paragraph (d)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(d)) of this section."
+                  "description": "Nothwithstanding paragraph (d)(2) of this section, if a health oversight activity or investigation is conducted in conjunction with an oversight activity or investigation relating to a claim for public benefits not related to health, the joint activity or investigation is considered a health oversight activity for purposes of paragraph (d) of this section."
                 },
                 {
                   "ref": "164.512(d)(4)",
                   "label": "Permitted uses",
-                  "description": "If a covered entity also is a health oversight agency, the covered entity may use protected health information for health oversight activities as permitted by [paragraph (d)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(d)) of this section."
+                  "description": "If a covered entity also is a health oversight agency, the covered entity may use protected health information for health oversight activities as permitted by paragraph (d) of this section."
                 }
               ]
             },
             {
               "ref": "164.512(e)",
               "label": "Standard: Disclosures for judicial and administrative proceedings",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(e)(1)",
                   "label": "Permitted disclosures.",
                   "description": "A covered entity may disclose protected health information in the course of any judicial or administrative proceeding:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(e)(1)(i)",
@@ -1963,20 +2092,22 @@
                     {
                       "ref": "164.512(e)(1)(ii)",
                       "label": "In response to a subpoena, discovery request, or other lawful process, that is not accompanied by an order of a court or administrative tribunal, if:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(e)(1)(ii)(A)",
-                          "label": "The covered entity receives satisfactory assurance, as described in [paragraph (e)(1)(iii)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(iii)) of this section, from the party seeking the information that reasonable efforts have been made by such party to ensure that the individual who is the subject of the protected health information that has been requested has been given notice of the request; or"
+                          "label": "The covered entity receives satisfactory assurance, as described in paragraph (e)(1)(iii) of this section, from the party seeking the information that reasonable efforts have been made by such party to ensure that the individual who is the subject of the protected health information that has been requested has been given notice of the request; or"
                         },
                         {
                           "ref": "164.512(e)(1)(ii)(B)",
-                          "label": "The covered entity receives satisfactory assurance, as described in [paragraph (e)(1)(iv)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(iv)) of this section, from the party seeking the information that reasonable efforts have been made by such party to secure a qualified protective order that meets the requirements of [paragraph (e)(1)(v)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(v)) of this section."
+                          "label": "The covered entity receives satisfactory assurance, as described in paragraph (e)(1)(iv) of this section, from the party seeking the information that reasonable efforts have been made by such party to secure a qualified protective order that meets the requirements of paragraph (e)(1)(v) of this section."
                         }
                       ]
                     },
                     {
                       "ref": "164.512(e)(1)(iii)",
-                      "label": "For the purposes of [paragraph (e)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(ii)(A)) of this section, a covered entity receives satisfactory assurances from a party seeking protected health information if the covered entity receives from such party a written statement and accompanying documentation demonstrating that:",
+                      "label": "For the purposes of paragraph (e)(1)(ii)(A) of this section, a covered entity receives satisfactory assurances from a party seeking protected health information if the covered entity receives from such party a written statement and accompanying documentation demonstrating that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(e)(1)(iii)(A)",
@@ -1989,6 +2120,7 @@
                         {
                           "ref": "164.512(e)(1)(iii)(C)",
                           "label": "The notice included sufficient information about the litigation or proceeding in which the protected health information is requested to permit the individual to raise an objection to the court or administrative tribunal; and",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.512(e)(1)(iii)(C)(1)",
@@ -2004,7 +2136,8 @@
                     },
                     {
                       "ref": "164.512(e)(1)(iv)",
-                      "label": "For the purposes of [paragraph (e)(1)(ii)(B)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(ii)(B)) of this section, a covered entity receives satisfactory assurances from a party seeking protected health information, if the covered entity receives from such party a written statement and accompanying documentation demonstrating that:",
+                      "label": "For the purposes of paragraph (e)(1)(ii)(B) of this section, a covered entity receives satisfactory assurances from a party seeking protected health information, if the covered entity receives from such party a written statement and accompanying documentation demonstrating that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(e)(1)(iv)(A)",
@@ -2018,7 +2151,8 @@
                     },
                     {
                       "ref": "164.512(e)(1)(v)",
-                      "label": "For purposes of [paragraph (e)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)) of this section, a qualified protective order means, with respect to protected health information requested under [paragraph (e)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(ii)) of this section, an order of a court or of an administrative tribunal or a stipulation by the parties to the litigation or administrative proceeding that:",
+                      "label": "For purposes of paragraph (e)(1) of this section, a qualified protective order means, with respect to protected health information requested under paragraph (e)(1)(ii) of this section, an order of a court or of an administrative tribunal or a stipulation by the parties to the litigation or administrative proceeding that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(e)(1)(v)(A)",
@@ -2032,7 +2166,7 @@
                     },
                     {
                       "ref": "164.512(e)(1)(vi)",
-                      "label": "Notwithstanding [paragraph (e)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(ii)) of this section, a covered entity may disclose protected health information in response to lawful process described in [paragraph (e)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(ii)) of this section without receiving satisfactory assurance under [paragraph (e)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(ii)(A)) or [(B)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(ii)(B)) of this section, if the covered entity makes reasonable efforts to provide notice to the individual sufficient to meet the requirements of [paragraph (e)(1)(iii)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(iii)) of this section or to seek a qualified protective order sufficient to meet the requirements of [paragraph (e)(1)(v)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(e)(1)(v)) of this section."
+                      "label": "Notwithstanding paragraph (e)(1)(ii) of this section, a covered entity may disclose protected health information in response to lawful process described in paragraph (e)(1)(ii) of this section without receiving satisfactory assurance under paragraph (e)(1)(ii)(A) or (B) of this section, if the covered entity makes reasonable efforts to provide notice to the individual sufficient to meet the requirements of paragraph (e)(1)(iii) of this section or to seek a qualified protective order sufficient to meet the requirements of paragraph (e)(1)(v) of this section."
                     }
                   ]
                 },
@@ -2044,20 +2178,23 @@
             },
             {
               "ref": "164.512(f)",
-              "label": "A covered entity may disclose protected health information for a law enforcement purpose to a law enforcement official if the conditions in [paragraphs (f)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(1)) through [(f)(6)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(6)) of this section are met, as applicable.",
+              "label": "A covered entity may disclose protected health information for a law enforcement purpose to a law enforcement official if the conditions in paragraphs (f)(1) through (f)(6) of this section are met, as applicable.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(f)(1)",
-                  "label": "**Permitted disclosures: Pursuant to process and as otherwise required by law.**",
+                  "label": "Permitted disclosures: Pursuant to process and as otherwise required by law.",
                   "description": "A covered entity may disclose protected health information:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(f)(1)(i)",
-                      "label": "As required by law including laws that require the reporting of certain types of wounds or other physical injuries, except for laws subject to [paragraph (b)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(b)(1)(ii)) or [(c)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(c)(1)(i)) of this section; or"
+                      "label": "As required by law including laws that require the reporting of certain types of wounds or other physical injuries, except for laws subject to paragraph (b)(1)(ii) or (c)(1)(i) of this section; or"
                     },
                     {
                       "ref": "164.512(f)(1)(ii)",
                       "label": "In compliance with and as limited by the relevant requirements of:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(f)(1)(ii)(A)",
@@ -2070,6 +2207,7 @@
                         {
                           "ref": "164.512(f)(1)(ii)(C)",
                           "label": "An administrative request for which response is required by law, including an administrative subpoena or summons, a civil or an authorized investigative demand, or similar process authorized under law, provided that:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.512(f)(1)(ii)(C)(1)",
@@ -2092,11 +2230,13 @@
                 {
                   "ref": "164.512(f)(2)",
                   "label": "Permitted disclosures: Limited information for identification and location purposes",
-                  "description": "Except for disclosures required by law as permitted by [paragraph (f)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(1)) of this section, a covered entity may disclose protected health information in response to a law enforcement official's request for such information for the purpose of identifying or locating a suspect, fugitive, material witness, or missing person, provided that:",
+                  "description": "Except for disclosures required by law as permitted by paragraph (f)(1) of this section, a covered entity may disclose protected health information in response to a law enforcement official's request for such information for the purpose of identifying or locating a suspect, fugitive, material witness, or missing person, provided that:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(f)(2)(i)",
                       "label": "The covered entity may disclose only the following information:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(f)(2)(i)(A)",
@@ -2134,14 +2274,15 @@
                     },
                     {
                       "ref": "164.512(f)(2)(ii)",
-                      "label": "Except as permitted by [paragraph (f)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(2)(i)) of this section, the covered entity may not disclose for the purposes of identification or location under [paragraph (f)(2)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(2)) of this section any protected health information related to the individual's DNA or DNA analysis, dental records, or typing, samples or analysis of body fluids or tissue."
+                      "label": "Except as permitted by paragraph (f)(2)(i) of this section, the covered entity may not disclose for the purposes of identification or location under paragraph (f)(2) of this section any protected health information related to the individual's DNA or DNA analysis, dental records, or typing, samples or analysis of body fluids or tissue."
                     }
                   ]
                 },
                 {
                   "ref": "164.512(f)(3)",
                   "label": "Permitted disclosure: Victims of a crime",
-                  "description": "Except for disclosures required by law as permitted by [paragraph (f)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(1)) of this section, a covered entity may disclose protected health information in response to a law enforcement official's request for such information about an individual who is or is suspected to be a victim of a crime, other than disclosures that are subject to [paragraph (b)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(b)) or [(c)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(c)) of this section, if:",
+                  "description": "Except for disclosures required by law as permitted by paragraph (f)(1) of this section, a covered entity may disclose protected health information in response to a law enforcement official's request for such information about an individual who is or is suspected to be a victim of a crime, other than disclosures that are subject to paragraph (b) or (c) of this section, if:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(f)(3)(i)",
@@ -2150,6 +2291,7 @@
                     {
                       "ref": "164.512(f)(3)(ii)",
                       "label": "The covered entity is unable to obtain the individual's agreement because of incapacity or other emergency circumstance, provided that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(f)(3)(ii)(A)",
@@ -2169,7 +2311,7 @@
                 },
                 {
                   "ref": "164.512(f)(4)",
-                  "label": "**Permitted disclosure: Decedents.**",
+                  "label": "Permitted disclosure: Decedents.",
                   "description": "A covered entity may disclose protected health information about an individual who has died to a law enforcement official for the purpose of alerting law enforcement of the death of the individual if the covered entity has a suspicion that such death may have resulted from criminal conduct."
                 },
                 {
@@ -2181,10 +2323,12 @@
                   "ref": "164.512(f)(6)",
                   "label": "Permitted disclosure: Reporting crime in emergencies.",
                   "description": "A covered entity may disclose to a law enforcement official protected health information that the covered entity believes in good faith constitutes evidence of criminal conduct that occurred on the premises of the covered entity.",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(f)(6)(i)",
                       "label": "A covered health care provider providing emergency health care in response to a medical emergency, other than such emergency on the premises of the covered health care provider, may disclose protected health information to a law enforcement official if such disclosure appears necessary to alert law enforcement to:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(f)(6)(i)(A)",
@@ -2202,7 +2346,7 @@
                     },
                     {
                       "ref": "164.512(f)(6)(ii)",
-                      "label": "If a covered health care provider believes that the medical emergency described in [paragraph (f)(6)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(6)(i)) of this section is the result of abuse, neglect, or domestic violence of the individual in need of emergency health care, [paragraph (f)(6)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(6)(i)) of this section does not apply and any disclosure to a law enforcement official for law enforcement purposes is subject to [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(c)) of this section."
+                      "label": "If a covered health care provider believes that the medical emergency described in paragraph (f)(6)(i) of this section is the result of abuse, neglect, or domestic violence of the individual in need of emergency health care, paragraph (f)(6)(i) of this section does not apply and any disclosure to a law enforcement official for law enforcement purposes is subject to paragraph (c) of this section."
                     }
                   ]
                 }
@@ -2211,6 +2355,7 @@
             {
               "ref": "164.512(g)",
               "label": "Standard: Uses and disclosures about decedents",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(g)(1)",
@@ -2232,24 +2377,28 @@
             {
               "ref": "164.512(i)",
               "label": "Standard: Uses and disclosures for research purposes",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(i)(1)",
                   "label": "Permitted uses and disclosures",
                   "description": "A covered entity may use or disclose protected health information for research, regardless of the source of funding of the research, provided that:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(i)(1)(i)",
-                      "label": "**Board approval of a waiver of authorization.**",
-                      "description": "The covered entity obtains documentation that an alteration to or waiver, in whole or in part, of the individual authorization required by [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508) for use or disclosure of protected health information has been approved by either:",
+                      "label": "Board approval of a waiver of authorization.",
+                      "description": "The covered entity obtains documentation that an alteration to or waiver, in whole or in part, of the individual authorization required by § 164.508 for use or disclosure of protected health information has been approved by either:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.512(i)(1)(i)(A)",
-                          "label": "An Institutional Review Board (IRB), established in accordance with 7 CFR lc.107, [10 CFR 745.107](https://www.ecfr.gov/current/title-10/section-745.107), [14 CFR 1230.107](https://www.ecfr.gov/current/title-14/section-1230.107), [15 CFR 27.107](https://www.ecfr.gov/current/title-15/section-27.107), [16 CFR 1028.107](https://www.ecfr.gov/current/title-16/section-1028.107), [21 CFR 56.107](https://www.ecfr.gov/current/title-21/section-56.107), [22 CFR 225.107](https://www.ecfr.gov/current/title-22/section-225.107), [24 CFR 60.107](https://www.ecfr.gov/current/title-24/section-60.107), [28 CFR 46.107](https://www.ecfr.gov/current/title-28/section-46.107), [32 CFR 219.107](https://www.ecfr.gov/current/title-32/section-219.107), [34 CFR 97.107](https://www.ecfr.gov/current/title-34/section-97.107), [38 CFR 16.107](https://www.ecfr.gov/current/title-38/section-16.107), [40 CFR 26.107](https://www.ecfr.gov/current/title-40/section-26.107), [45 CFR 46.107](https://www.ecfr.gov/current/title-45/section-46.107), [45 CFR 690.107](https://www.ecfr.gov/current/title-45/section-690.107), or [49 CFR 11.107](https://www.ecfr.gov/current/title-49/section-11.107); or"
+                          "label": "An Institutional Review Board (IRB), established in accordance with 7 CFR lc.107, 10 CFR 745.107, 14 CFR 1230.107, 15 CFR 27.107, 16 CFR 1028.107, 21 CFR 56.107, 22 CFR 225.107, 24 CFR 60.107, 28 CFR 46.107, 32 CFR 219.107, 34 CFR 97.107, 38 CFR 16.107, 40 CFR 26.107, 45 CFR 46.107, 45 CFR 690.107, or 49 CFR 11.107; or"
                         },
                         {
                           "ref": "164.512(i)(1)(i)(B)",
                           "label": "A privacy board that:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.512(i)(1)(i)(B)(1)",
@@ -2271,6 +2420,7 @@
                       "ref": "164.512(i)(1)(ii)",
                       "label": "Reviews preparatory to research",
                       "description": "The covered entity obtains from the researcher representations that:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.512(i)(1)(ii)(A)",
@@ -2290,6 +2440,7 @@
                       "ref": "164.512(i)(1)(iii)",
                       "label": "Research on decedent's information",
                       "description": "The covered entity obtains from the researcher:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.512(i)(1)(iii)(A)",
@@ -2310,7 +2461,8 @@
                 {
                   "ref": "164.512(i)(2)",
                   "label": "Documentation of waiver approval.",
-                  "description": "For a use or disclosure to be permitted based on documentation of approval of an alteration or waiver, under [paragraph (i)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)(1)(i)) of this section, the documentation must include all of the following:",
+                  "description": "For a use or disclosure to be permitted based on documentation of approval of an alteration or waiver, under paragraph (i)(1)(i) of this section, the documentation must include all of the following:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(i)(2)(i)",
@@ -2321,10 +2473,12 @@
                       "ref": "164.512(i)(2)(ii)",
                       "label": "Waiver criteria",
                       "description": "A statement that the IRB or privacy board has determined that the alteration or waiver, in whole or in part, of authorization satisfies the following criteria:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.512(i)(2)(ii)(A)",
                           "label": "The use or disclosure of protected health information involves no more than a minimal risk to the privacy of individuals, based on, at least, the presence of the following elements;",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.512(i)(2)(ii)(A)(1)",
@@ -2352,21 +2506,22 @@
                     },
                     {
                       "ref": "164.512(i)(2)(iii)",
-                      "label": "**Protected health information needed.**",
-                      "description": "A brief description of the protected health information for which use or access has been determined to be necessary by the institutional review board or privacy board, pursuant to [paragraph (i)(2)(ii)(C)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)(2)(ii)(C)) of this section;"
+                      "label": "Protected health information needed.",
+                      "description": "A brief description of the protected health information for which use or access has been determined to be necessary by the institutional review board or privacy board, pursuant to paragraph (i)(2)(ii)(C) of this section;"
                     },
                     {
                       "ref": "164.512(i)(2)(iv)",
                       "label": "Review and approval procedures",
                       "description": "A statement that the alteration or waiver of authorization has been reviewed and approved under either normal or expedited review procedures, as follows:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.512(i)(2)(iv)(A)",
-                          "label": "An IRB must follow the requirements of the Common Rule, including the normal review procedures ([7 CFR 1c.108(b)](https://www.ecfr.gov/current/title-7/section-1c.108#p-1c.108(b)), [10 CFR 745.108(b)](https://www.ecfr.gov/current/title-10/section-745.108#p-745.108(b)), [14 CFR 1230.108(b)](https://www.ecfr.gov/current/title-14/section-1230.108#p-1230.108(b)), [15 CFR 27.108(b)](https://www.ecfr.gov/current/title-15/section-27.108#p-27.108(b)), [16 CFR 1028.108(b)](https://www.ecfr.gov/current/title-16/section-1028.108#p-1028.108(b)), [21 CFR 56.108(b)](https://www.ecfr.gov/current/title-21/section-56.108#p-56.108(b)), [22 CFR 225.108(b)](https://www.ecfr.gov/current/title-22/section-225.108#p-225.108(b)), [24 CFR 60.108(b)](https://www.ecfr.gov/current/title-24/section-60.108#p-60.108(b)), [28 CFR 46.108(b)](https://www.ecfr.gov/current/title-28/section-46.108#p-46.108(b)), [32 CFR 219.108(b)](https://www.ecfr.gov/current/title-32/section-219.108#p-219.108(b)), [34 CFR 97.108(b)](https://www.ecfr.gov/current/title-34/section-97.108#p-97.108(b)), [38 CFR 16.108(b)](https://www.ecfr.gov/current/title-38/section-16.108#p-16.108(b)), [40 CFR 26.108(b)](https://www.ecfr.gov/current/title-40/section-26.108#p-26.108(b)), [45 CFR 46.108(b)](https://www.ecfr.gov/current/title-45/section-46.108#p-46.108(b)), [45 CFR 690.108(b)](https://www.ecfr.gov/current/title-45/section-690.108#p-690.108(b)), or [49 CFR 11.108(b)](https://www.ecfr.gov/current/title-49/section-11.108#p-11.108(b))) or the expedited review procedures ([7 CFR 1c.110](https://www.ecfr.gov/current/title-7/section-1c.110), [10 CFR 745.110](https://www.ecfr.gov/current/title-10/section-745.110), [14 CFR 1230.110](https://www.ecfr.gov/current/title-14/section-1230.110), [15 CFR 27.110](https://www.ecfr.gov/current/title-15/section-27.110), [16 CFR 1028.110](https://www.ecfr.gov/current/title-16/section-1028.110), [21 CFR 56.110](https://www.ecfr.gov/current/title-21/section-56.110), [22 CFR 225.110](https://www.ecfr.gov/current/title-22/section-225.110), [24 CFR 60.110](https://www.ecfr.gov/current/title-24/section-60.110), [28 CFR 46.110](https://www.ecfr.gov/current/title-28/section-46.110), [32 CFR 219.110](https://www.ecfr.gov/current/title-32/section-219.110), [34 CFR 97.110](https://www.ecfr.gov/current/title-34/section-97.110), [38 CFR 16.110](https://www.ecfr.gov/current/title-38/section-16.110), [40 CFR 26.110](https://www.ecfr.gov/current/title-40/section-26.110), [45 CFR 46.110](https://www.ecfr.gov/current/title-45/section-46.110), [45 CFR 690.110](https://www.ecfr.gov/current/title-45/section-690.110), or [49 CFR 11.110](https://www.ecfr.gov/current/title-49/section-11.110));"
+                          "label": "An IRB must follow the requirements of the Common Rule, including the normal review procedures (7 CFR 1c.108(b), 10 CFR 745.108(b), 14 CFR 1230.108(b), 15 CFR 27.108(b), 16 CFR 1028.108(b), 21 CFR 56.108(b), 22 CFR 225.108(b), 24 CFR 60.108(b), 28 CFR 46.108(b), 32 CFR 219.108(b), 34 CFR 97.108(b), 38 CFR 16.108(b), 40 CFR 26.108(b), 45 CFR 46.108(b), 45 CFR 690.108(b), or 49 CFR 11.108(b)) or the expedited review procedures (7 CFR 1c.110, 10 CFR 745.110, 14 CFR 1230.110, 15 CFR 27.110, 16 CFR 1028.110, 21 CFR 56.110, 22 CFR 225.110, 24 CFR 60.110, 28 CFR 46.110, 32 CFR 219.110, 34 CFR 97.110, 38 CFR 16.110, 40 CFR 26.110, 45 CFR 46.110, 45 CFR 690.110, or 49 CFR 11.110);"
                         },
                         {
                           "ref": "164.512(i)(2)(iv)(B)",
-                          "label": "A privacy board must review the proposed research at convened meetings at which a majority of the privacy board members are present, including at least one member who satisfies the criterion stated in [paragraph (i)(1)(i)(B)(2)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)(1)(i)(B)(2)) of this section, and the alteration or waiver of authorization must be approved by the majority of the privacy board members present at the meeting, unless the privacy board elects to use an expedited review procedure in accordance with [paragraph (i)(2)(iv)(C)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)(2)(iv)(C)) of this section;"
+                          "label": "A privacy board must review the proposed research at convened meetings at which a majority of the privacy board members are present, including at least one member who satisfies the criterion stated in paragraph (i)(1)(i)(B)(2) of this section, and the alteration or waiver of authorization must be approved by the majority of the privacy board members present at the meeting, unless the privacy board elects to use an expedited review procedure in accordance with paragraph (i)(2)(iv)(C) of this section;"
                         },
                         {
                           "ref": "164.512(i)(2)(iv)(C)",
@@ -2386,14 +2541,17 @@
             {
               "ref": "164.512(j)",
               "label": "Standard: Uses and disclosures to avert a serious threat to health or safety",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(j)(1)",
                   "label": "Permitted disclosures.",
                   "description": "A covered entity may, consistent with applicable law and standards of ethical conduct, use or disclose protected health information, if the covered entity, in good faith, believes the use or disclosure:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(j)(1)(i)",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(j)(1)(i)(A)",
@@ -2408,6 +2566,7 @@
                     {
                       "ref": "164.512(j)(1)(ii)",
                       "label": "Is necessary for law enforcement authorities to identify or apprehend an individual:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(j)(1)(ii)(A)",
@@ -2415,7 +2574,7 @@
                         },
                         {
                           "ref": "164.512(j)(1)(ii)(B)",
-                          "label": "Where it appears from all the circumstances that the individual has escaped from a correctional institution or from lawful custody, as those terms are defined in [§ 164.501](https://www.ecfr.gov/current/title-45/section-164.501)."
+                          "label": "Where it appears from all the circumstances that the individual has escaped from a correctional institution or from lawful custody, as those terms are defined in § 164.501."
                         }
                       ]
                     }
@@ -2424,41 +2583,45 @@
                 {
                   "ref": "164.512(j)(2)",
                   "label": "Use or disclosure not permitted.",
-                  "description": "A use or disclosure pursuant to [paragraph (j)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(ii)(A)) of this section may not be made if the information described in [paragraph (j)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(ii)(A)) of this section is learned by the covered entity:",
+                  "description": "A use or disclosure pursuant to paragraph (j)(1)(ii)(A) of this section may not be made if the information described in paragraph (j)(1)(ii)(A) of this section is learned by the covered entity:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(j)(2)(i)",
-                      "label": "In the course of treatment to affect the propensity to commit the criminal conduct that is the basis for the disclosure under [paragraph (j)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(ii)(A)) of this section, or counseling or therapy; or"
+                      "label": "In the course of treatment to affect the propensity to commit the criminal conduct that is the basis for the disclosure under paragraph (j)(1)(ii)(A) of this section, or counseling or therapy; or"
                     },
                     {
                       "ref": "164.512(j)(2)(ii)",
-                      "label": "Through a request by the individual to initiate or to be referred for the treatment, counseling, or therapy described in [paragraph (j)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(2)(i)) of this section."
+                      "label": "Through a request by the individual to initiate or to be referred for the treatment, counseling, or therapy described in paragraph (j)(2)(i) of this section."
                     }
                   ]
                 },
                 {
                   "ref": "164.512(j)(3)",
-                  "label": "**Limit on information that may be disclosed.**",
-                  "description": "A disclosure made pursuant to [paragraph (j)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(ii)(A)) of this section shall contain only the statement described in [paragraph (j)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(ii)(A)) of this section and the protected health information described in [paragraph (f)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(2)(i)) of this section."
+                  "label": "Limit on information that may be disclosed.",
+                  "description": "A disclosure made pursuant to paragraph (j)(1)(ii)(A) of this section shall contain only the statement described in paragraph (j)(1)(ii)(A) of this section and the protected health information described in paragraph (f)(2)(i) of this section."
                 },
                 {
                   "ref": "164.512(j)(4)",
                   "label": "Presumption of good faith belief.",
-                  "description": "A covered entity that uses or discloses protected health information pursuant to [paragraph (j)(1)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)) of this section is presumed to have acted in good faith with regard to a belief described in [paragraph (j)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(i)) or [(ii)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(ii)) of this section, if the belief is based upon the covered entity's actual knowledge or in reliance on a credible representation by a person with apparent knowledge or authority."
+                  "description": "A covered entity that uses or discloses protected health information pursuant to paragraph (j)(1) of this section is presumed to have acted in good faith with regard to a belief described in paragraph (j)(1)(i) or (ii) of this section, if the belief is based upon the covered entity's actual knowledge or in reliance on a credible representation by a person with apparent knowledge or authority."
                 }
               ]
             },
             {
               "ref": "164.512(k)",
               "label": "Standard: Uses and disclosures for specialized government functions",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.512(k)(1)",
-                  "label": "**Military and veterans activities**",
+                  "label": "Military and veterans activities",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.512(k)(1)(i)",
                       "label": "Armed Forces personnel",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(k)(1)(i)(A)",
@@ -2482,24 +2645,25 @@
                     {
                       "ref": "164.512(k)(1)(iv)",
                       "label": "Foreign military personnel.",
-                      "description": "A covered entity may use and disclose the protected health information of individuals who are foreign military personnel to their appropriate foreign military authority for the same purposes for which uses and disclosures are permitted for Armed Forces personnel under the notice published in the Federal Register pursuant to [paragraph (k)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(k)(1)(i)) of this section."
+                      "description": "A covered entity may use and disclose the protected health information of individuals who are foreign military personnel to their appropriate foreign military authority for the same purposes for which uses and disclosures are permitted for Armed Forces personnel under the notice published in the Federal Register pursuant to paragraph (k)(1)(i) of this section."
                     }
                   ]
                 },
                 {
                   "ref": "164.512(k)(2)",
                   "label": "National security and intelligence activities",
-                  "description": "A covered entity may disclose protected health information to authorized federal officials for the conduct of lawful intelligence, counter-intelligence, and other national security activities authorized by the National Security Act ([50 U.S.C. 401](https://www.govinfo.gov/link/uscode/50/401), *et seq.*) and implementing authority (*e.g.,* Executive Order 12333)."
+                  "description": "A covered entity may disclose protected health information to authorized federal officials for the conduct of lawful intelligence, counter-intelligence, and other national security activities authorized by the National Security Act (50 U.S.C. 401, et seq.) and implementing authority (e.g., Executive Order 12333)."
                 },
                 {
                   "ref": "164.512(k)(3)",
                   "label": "Protective services for the President and others",
-                  "description": "A covered entity may disclose protected health information to authorized Federal officials for the provision of protective services to the President or other persons authorized by [18 U.S.C. 3056](https://www.govinfo.gov/link/uscode/18/3056) or to foreign heads of state or other persons authorized by [22 U.S.C. 2709(a)(3)](https://www.govinfo.gov/link/uscode/22/2709), or for the conduct of investigations authorized by [18 U.S.C. 871](https://www.govinfo.gov/link/uscode/18/871) and [879](https://www.govinfo.gov/link/uscode/18/879)."
+                  "description": "A covered entity may disclose protected health information to authorized Federal officials for the provision of protective services to the President or other persons authorized by 18 U.S.C. 3056 or to foreign heads of state or other persons authorized by 22 U.S.C. 2709(a)(3), or for the conduct of investigations authorized by 18 U.S.C. 871 and 879."
                 },
                 {
                   "ref": "164.512(k)(4)",
                   "label": "Medical suitability determinations.",
                   "description": "A covered entity that is a component of the Department of State may use protected health information to make medical suitability determinations and may disclose whether or not the individual was determined to be medically suitable to the officials in the Department of State who need access to such information for the following purposes:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(k)(4)(i)",
@@ -2518,11 +2682,13 @@
                 {
                   "ref": "164.512(k)(5)",
                   "label": "Correctional institutions and other law enforcement custodial situations",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.512(k)(5)(i)",
                       "label": "Permitted disclosures",
                       "description": "A covered entity may disclose to a correctional institution or a law enforcement official having lawful custody of an inmate or other individual protected health information about such inmate or individual, if the correctional institution or such law enforcement official represents that such protected health information is necessary for:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.512(k)(5)(i)(A)",
@@ -2565,6 +2731,7 @@
                 {
                   "ref": "164.512(k)(6)",
                   "label": "Covered entities that are government programs providing public benefits.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.512(k)(6)(i)",
@@ -2578,12 +2745,14 @@
                 },
                 {
                   "ref": "164.512(k)(7)",
-                  "label": "**National Instant Criminal Background Check System.**",
-                  "description": "A covered entity may use or disclose protected health information for purposes of reporting to the National Instant Criminal Background Check System the identity of an individual who is prohibited from possessing a firearm under [18 U.S.C. 922(g)(4)](https://www.govinfo.gov/link/uscode/18/922), provided the covered entity:",
+                  "label": "National Instant Criminal Background Check System.",
+                  "description": "A covered entity may use or disclose protected health information for purposes of reporting to the National Instant Criminal Background Check System the identity of an individual who is prohibited from possessing a firearm under 18 U.S.C. 922(g)(4), provided the covered entity:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.512(k)(7)(i)",
                       "label": "Is a State agency or other entity that is, or contains an entity that is:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(k)(7)(i)(A)",
@@ -2591,13 +2760,14 @@
                         },
                         {
                           "ref": "164.512(k)(7)(i)(B)",
-                          "label": "A court, board, commission, or other lawful authority that makes the commitment or adjudication that causes an individual to become subject to [18 U.S.C. 922(g)(4)](https://www.govinfo.gov/link/uscode/18/922); and"
+                          "label": "A court, board, commission, or other lawful authority that makes the commitment or adjudication that causes an individual to become subject to 18 U.S.C. 922(g)(4); and"
                         }
                       ]
                     },
                     {
                       "ref": "164.512(k)(7)(ii)",
                       "label": "Discloses the information only to:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(k)(7)(ii)(A)",
@@ -2611,6 +2781,7 @@
                     },
                     {
                       "ref": "164.512(k)(7)(iii)",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.512(k)(7)(iii)(A)",
@@ -2636,6 +2807,7 @@
         {
           "ref": "164.514",
           "label": "Other requirements relating to uses and disclosures of protected health information.",
+          "group": true,
           "controls": [
             {
               "ref": "164.514(a)",
@@ -2646,10 +2818,12 @@
               "ref": "164.514(b)",
               "label": "Implementation specifications: Requirements for de-identification of protected health information.",
               "description": "A covered entity may determine that health information is not individually identifiable health information only if:",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.514(b)(1)",
                   "label": "A person with appropriate knowledge of and experience with generally accepted statistical and scientific principles and methods for rendering information not individually identifiable:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(b)(1)(i)",
@@ -2663,10 +2837,12 @@
                 },
                 {
                   "ref": "164.514(b)(2)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(b)(2)(i)",
                       "label": "The following identifiers of the individual or of relatives, employers, or household members of the individual, are removed:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.514(b)(2)(i)(A)",
@@ -2675,6 +2851,7 @@
                         {
                           "ref": "164.514(b)(2)(i)(B)",
                           "label": "All geographic subdivisions smaller than a State, including street address, city, county, precinct, zip code, and their equivalent geocodes, except for the initial three digits of a zip code if, according to the current publicly available data from the Bureau of the Census:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.514(b)(2)(i)(B)(1)",
@@ -2748,7 +2925,7 @@
                         },
                         {
                           "ref": "164.514(b)(2)(i)(R)",
-                          "label": "Any other unique identifying number, characteristic, or code, except as permitted by [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(c)) of this section; and"
+                          "label": "Any other unique identifying number, characteristic, or code, except as permitted by paragraph (c) of this section; and"
                         }
                       ]
                     },
@@ -2764,34 +2941,38 @@
               "ref": "164.514(c)",
               "label": "Implementation specifications: Re-identification",
               "description": "A covered entity may assign a code or other means of record identification to allow information de-identified under this section to be re-identified by the covered entity, provided that:",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.514(c)(1)",
-                  "label": "**Derivation**",
+                  "label": "Derivation",
                   "description": "The code or other means of record identification is not derived from or related to information about the individual and is not otherwise capable of being translated so as to identify the individual; and"
                 },
                 {
                   "ref": "164.514(c)(2)",
-                  "label": "**Security.**",
+                  "label": "Security.",
                   "description": "The covered entity does not use or disclose the code or other means of record identification for any other purpose, and does not disclose the mechanism for re-identification."
                 }
               ]
             },
             {
               "ref": "164.514(d)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.514(d)(1)",
                   "label": "Standard: minimum necessary requirements",
-                  "description": "In order to comply with [§ 164.502(b)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(b)) and this section, a covered entity must meet the requirements of [paragraphs (d)(2)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(d)(2)) through [(d)(5)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(d)(5)) of this section with respect to a request for, or the use and disclosure of, protected health information."
+                  "description": "In order to comply with § 164.502(b) and this section, a covered entity must meet the requirements of paragraphs (d)(2) through (d)(5) of this section with respect to a request for, or the use and disclosure of, protected health information."
                 },
                 {
                   "ref": "164.514(d)(2)",
                   "label": "Implementation specifications: Minimum necessary uses of protected health information.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(d)(2)(i)",
                       "label": "A covered entity must identify:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.514(d)(2)(i)(A)",
@@ -2805,13 +2986,14 @@
                     },
                     {
                       "ref": "164.514(d)(2)(ii)",
-                      "label": "A covered entity must make reasonable efforts to limit the access of such persons or classes identified in [paragraph (d)(2)(i)(A)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(d)(2)(i)(A)) of this section to protected health information consistent with [paragraph (d)(2)(i)(B)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(d)(2)(i)(B)) of this section."
+                      "label": "A covered entity must make reasonable efforts to limit the access of such persons or classes identified in paragraph (d)(2)(i)(A) of this section to protected health information consistent with paragraph (d)(2)(i)(B) of this section."
                     }
                   ]
                 },
                 {
                   "ref": "164.514(d)(3)",
                   "label": "Implementation specification: Minimum necessary disclosures of protected health information.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(d)(3)(i)",
@@ -2820,6 +3002,7 @@
                     {
                       "ref": "164.514(d)(3)(ii)",
                       "label": "For all other disclosures, a covered entity must:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.514(d)(3)(ii)(A)",
@@ -2834,10 +3017,11 @@
                     {
                       "ref": "164.514(d)(3)(iii)",
                       "label": "A covered entity may rely, if such reliance is reasonable under the circumstances, on a requested disclosure as the minimum necessary for the stated purpose when:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.514(d)(3)(iii)(A)",
-                          "label": "Making disclosures to public officials that are permitted under [§ 164.512](https://www.ecfr.gov/current/title-45/section-164.512), if the public official represents that the information requested is the minimum necessary for the stated purpose(s);"
+                          "label": "Making disclosures to public officials that are permitted under § 164.512, if the public official represents that the information requested is the minimum necessary for the stated purpose(s);"
                         },
                         {
                           "ref": "164.514(d)(3)(iii)(B)",
@@ -2849,7 +3033,7 @@
                         },
                         {
                           "ref": "164.514(d)(3)(iii)(D)",
-                          "label": "Documentation or representations that comply with the applicable requirements of [§ 164.512(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)) have been provided by a person requesting the information for research purposes."
+                          "label": "Documentation or representations that comply with the applicable requirements of § 164.512(i) have been provided by a person requesting the information for research purposes."
                         }
                       ]
                     }
@@ -2858,6 +3042,7 @@
                 {
                   "ref": "164.514(d)(4)",
                   "label": "Implementation specifications: Minimum necessary requests for protected health information.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(d)(4)(i)",
@@ -2870,6 +3055,7 @@
                     {
                       "ref": "164.514(d)(4)(iii)",
                       "label": "For all other requests, a covered entity must:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.514(d)(4)(iii)(A)",
@@ -2891,16 +3077,18 @@
             },
             {
               "ref": "164.514(e)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.514(e)(1)",
-                  "label": "**Standard: Limited data set.**",
-                  "description": "A covered entity may use or disclose a limited data set that meets the requirements of [paragraphs (e)(2)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)(2)) and [(e)(3)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)(3)) of this section, if the covered entity enters into a data use agreement with the limited data set recipient, in accordance with [paragraph (e)(4)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)(4)) of this section."
+                  "label": "Standard: Limited data set.",
+                  "description": "A covered entity may use or disclose a limited data set that meets the requirements of paragraphs (e)(2) and (e)(3) of this section, if the covered entity enters into a data use agreement with the limited data set recipient, in accordance with paragraph (e)(4) of this section."
                 },
                 {
                   "ref": "164.514(e)(2)",
                   "label": "Implementation specification: Limited data set:",
                   "description": "A limited data set is protected health information that excludes the following direct identifiers of the individual or of relatives, employers, or household members of the individual:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.514(e)(2)(i)",
@@ -2971,34 +3159,37 @@
                 {
                   "ref": "164.514(e)(3)",
                   "label": "Implementation specification: Permitted purposes for uses and disclosures.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(e)(3)(i)",
-                      "label": "A covered entity may use or disclose a limited data set under [paragraph (e)(1)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)(1)) of this section only for the purposes of research, public health, or health care operations"
+                      "label": "A covered entity may use or disclose a limited data set under paragraph (e)(1) of this section only for the purposes of research, public health, or health care operations"
                     },
                     {
                       "ref": "164.514(e)(3)(ii)",
-                      "label": "A covered entity may use protected health information to create a limited data set that meets the requirements of [paragraph (e)(2)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)(2)) of this section, or disclose protected health information only to a business associate for such purpose, whether or not the limited data set is to be used by the covered entity."
+                      "label": "A covered entity may use protected health information to create a limited data set that meets the requirements of paragraph (e)(2) of this section, or disclose protected health information only to a business associate for such purpose, whether or not the limited data set is to be used by the covered entity."
                     }
                   ]
                 },
                 {
                   "ref": "164.514(e)(4)",
-                  "label": "**Implementation specifications: Data use agreement**",
+                  "label": "Implementation specifications: Data use agreement",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(e)(4)(i)",
-                      "label": "**Agreement required.**",
-                      "description": "A covered entity may use or disclose a limited data set under [paragraph (e)(1)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)(1)) of this section only if the covered entity obtains satisfactory assurance, in the form of a data use agreement that meets the requirements of this section, that the limited data set recipient will only use or disclose the protected health information for limited purposes."
+                      "label": "Agreement required.",
+                      "description": "A covered entity may use or disclose a limited data set under paragraph (e)(1) of this section only if the covered entity obtains satisfactory assurance, in the form of a data use agreement that meets the requirements of this section, that the limited data set recipient will only use or disclose the protected health information for limited purposes."
                     },
                     {
                       "ref": "164.514(e)(4)(ii)",
                       "label": "Contents.",
                       "description": "A data use agreement between the covered entity and the limited data set recipient must:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.514(e)(4)(ii)(A)",
-                          "label": "Establish the permitted uses and disclosures of such information by the limited data set recipient, consistent with [paragraph (e)(3)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)(3)) of this section. The data use agreement may not authorize the limited data set recipient to use or further disclose the information in a manner that would violate the requirements of this subpart, if done by the covered entity;"
+                          "label": "Establish the permitted uses and disclosures of such information by the limited data set recipient, consistent with paragraph (e)(3) of this section. The data use agreement may not authorize the limited data set recipient to use or further disclose the information in a manner that would violate the requirements of this subpart, if done by the covered entity;"
                         },
                         {
                           "ref": "164.514(e)(4)(ii)(B)",
@@ -3007,6 +3198,7 @@
                         {
                           "ref": "164.514(e)(4)(ii)(C)",
                           "label": "Provide that the limited data set recipient will:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.514(e)(4)(ii)(C)(1)",
@@ -3034,11 +3226,13 @@
                     },
                     {
                       "ref": "164.514(e)(4)(iii)",
-                      "label": "**Compliance.**",
+                      "label": "Compliance.",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.514(e)(4)(iii)(A)",
-                          "label": "A covered entity is not in compliance with the standards in [paragraph (e)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)) of this section if the covered entity knew of a pattern of activity or practice of the limited data set recipient that constituted a material breach or violation of the data use agreement, unless the covered entity took reasonable steps to cure the breach or end the violation, as applicable, and, if such steps were unsuccessful:",
+                          "label": "A covered entity is not in compliance with the standards in paragraph (e) of this section if the covered entity knew of a pattern of activity or practice of the limited data set recipient that constituted a material breach or violation of the data use agreement, unless the covered entity took reasonable steps to cure the breach or end the violation, as applicable, and, if such steps were unsuccessful:",
+                          "group": true,
                           "controls": [
                             {
                               "ref": "164.514(e)(4)(iii)(A)(1)",
@@ -3052,7 +3246,7 @@
                         },
                         {
                           "ref": "164.514(e)(4)(iii)(B)",
-                          "label": "A covered entity that is a limited data set recipient and violates a data use agreement will be in noncompliance with the standards, implementation specifications, and requirements of [paragraph (e)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)) of this section."
+                          "label": "A covered entity that is a limited data set recipient and violates a data use agreement will be in noncompliance with the standards, implementation specifications, and requirements of paragraph (e) of this section."
                         }
                       ]
                     }
@@ -3063,11 +3257,13 @@
             {
               "ref": "164.514(f)",
               "label": "Fundraising communications",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.514(f)(1)",
-                  "label": "**Standard: Uses and disclosures for fundraising.**",
-                  "description": "Subject to the conditions of [paragraph (f)(2)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(f)(2)) of this section, a covered entity may use, or disclose to a business associate or to an institutionally related foundation, the following protected health information for the purpose of raising funds for its own benefit, without an authorization meeting the requirements of [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508):",
+                  "label": "Standard: Uses and disclosures for fundraising.",
+                  "description": "Subject to the conditions of paragraph (f)(2) of this section, a covered entity may use, or disclose to a business associate or to an institutionally related foundation, the following protected health information for the purpose of raising funds for its own benefit, without an authorization meeting the requirements of § 164.508:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.514(f)(1)(i)",
@@ -3098,10 +3294,11 @@
                 {
                   "ref": "164.514(f)(2)",
                   "label": "Implementation specifications: Fundraising requirements.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(f)(2)(i)",
-                      "label": "A covered entity may not use or disclose protected health information for fundraising purposes as otherwise permitted by [paragraph (f)(1)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(f)(1)) of this section unless a statement required by [§ 164.520(b)(1)(iii)(A)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(iii)(A)) is included in the covered entity's notice of privacy practices."
+                      "label": "A covered entity may not use or disclose protected health information for fundraising purposes as otherwise permitted by paragraph (f)(1) of this section unless a statement required by § 164.520(b)(1)(iii)(A) is included in the covered entity's notice of privacy practices."
                     },
                     {
                       "ref": "164.514(f)(2)(ii)",
@@ -3113,7 +3310,7 @@
                     },
                     {
                       "ref": "164.514(f)(2)(iv)",
-                      "label": "A covered entity may not make fundraising communications to an individual under this paragraph where the individual has elected not to receive such communications under [paragraph (f)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(f)(2)(ii)) of this section."
+                      "label": "A covered entity may not make fundraising communications to an individual under this paragraph where the individual has elected not to receive such communications under paragraph (f)(2)(ii) of this section."
                     },
                     {
                       "ref": "164.514(f)(2)(v)",
@@ -3126,19 +3323,21 @@
             {
               "ref": "164.514(g)",
               "label": "Standard: Uses and disclosures for underwriting and related purposes.",
-              "description": "If a health plan receives protected health information for the purpose of underwriting, premium rating, or other activities relating to the creation, renewal, or replacement of a contract of health insurance or health benefits, and if such health insurance or health benefits are not placed with the health plan, such health plan may only use or disclose such protected health information for such purpose or as may be required by law, subject to the prohibition at [§ 164.502(a)(5)(i)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(i)) with respect to genetic information included in the protected health information."
+              "description": "If a health plan receives protected health information for the purpose of underwriting, premium rating, or other activities relating to the creation, renewal, or replacement of a contract of health insurance or health benefits, and if such health insurance or health benefits are not placed with the health plan, such health plan may only use or disclose such protected health information for such purpose or as may be required by law, subject to the prohibition at § 164.502(a)(5)(i) with respect to genetic information included in the protected health information."
             },
             {
               "ref": "164.514(h)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.514(h)(1)",
-                  "label": "**Standard: Verification requirements.**",
+                  "label": "Standard: Verification requirements.",
                   "description": "Prior to any disclosure permitted by this subpart, a covered entity must:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.514(h)(1)(i)",
-                      "label": "Except with respect to disclosures under [§ 164.510](https://www.ecfr.gov/current/title-45/section-164.510), verify the identity of a person requesting protected health information and the authority of any such person to have access to protected health information under this subpart, if the identity or any such authority of such person is not known to the covered entity; and"
+                      "label": "Except with respect to disclosures under § 164.510, verify the identity of a person requesting protected health information and the authority of any such person to have access to protected health information under this subpart, if the identity or any such authority of such person is not known to the covered entity; and"
                     },
                     {
                       "ref": "164.514(h)(1)(ii)",
@@ -3149,19 +3348,21 @@
                 {
                   "ref": "164.514(h)(2)",
                   "label": "Implementation specifications: Verification",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.514(h)(2)(i)",
-                      "label": "**Conditions on disclosures.**",
+                      "label": "Conditions on disclosures.",
                       "description": "If a disclosure is conditioned by this subpart on particular documentation, statements, or representations from the person requesting the protected health information, a covered entity may rely, if such reliance is reasonable under the circumstances, on documentation, statements, or representations that, on their face, meet the applicable requirements.",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.514(h)(2)(i)(A)",
-                          "label": "The conditions in [§ 164.512(f)(1)(ii)(C)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)(1)(ii)(C)) may be satisfied by the administrative subpoena or similar process or by a separate written statement that, on its face, demonstrates that the applicable requirements have been met."
+                          "label": "The conditions in § 164.512(f)(1)(ii)(C) may be satisfied by the administrative subpoena or similar process or by a separate written statement that, on its face, demonstrates that the applicable requirements have been met."
                         },
                         {
                           "ref": "164.514(h)(2)(i)(B)",
-                          "label": "The documentation required by [§ 164.512(i)(2)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)(2)) may be satisfied by one or more written statements, provided that each is appropriately dated and signed in accordance with [§ 164.512(i)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)(2)(i)) and [(v)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)(2)(v))."
+                          "label": "The documentation required by § 164.512(i)(2) may be satisfied by one or more written statements, provided that each is appropriately dated and signed in accordance with § 164.512(i)(2)(i) and (v)."
                         }
                       ]
                     },
@@ -3169,6 +3370,7 @@
                       "ref": "164.514(h)(2)(ii)",
                       "label": "Identity of public officials.",
                       "description": "A covered entity may rely, if such reliance is reasonable under the circumstances, on any of the following to verify identity when the disclosure of protected health information is to a public official or a person acting on behalf of the public official:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.514(h)(2)(ii)(A)",
@@ -3188,6 +3390,7 @@
                       "ref": "164.514(h)(2)(iii)",
                       "label": "Authority of public officials.",
                       "description": "A covered entity may rely, if such reliance is reasonable under the circumstances, on any of the following to verify authority when the disclosure of protected health information is to a public official or a person acting on behalf of the public official:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.514(h)(2)(iii)(A)",
@@ -3202,7 +3405,7 @@
                     {
                       "ref": "164.514(h)(2)(iv)",
                       "label": "Exercise of professional judgment.",
-                      "description": "The verification requirements of this paragraph are met if the covered entity relies on the exercise of professional judgment in making a use or disclosure in accordance with [§ 164.510](https://www.ecfr.gov/current/title-45/section-164.510) or acts on a good faith belief in making a disclosure in accordance with [§ 164.512(j)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j))."
+                      "description": "The verification requirements of this paragraph are met if the covered entity relies on the exercise of professional judgment in making a use or disclosure in accordance with § 164.510 or acts on a good faith belief in making a disclosure in accordance with § 164.512(j)."
                     }
                   ]
                 }
@@ -3213,28 +3416,32 @@
         {
           "ref": "164.520",
           "label": "Notice of privacy practices for protected health information.",
+          "group": true,
           "controls": [
             {
               "ref": "164.520(a)",
               "label": "Standard: Notice of privacy practices",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.520(a)(1)",
                   "label": "Right to notice.",
-                  "description": "Except as provided by [paragraph (a)(3)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(a)(3)) or [(4)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(a)(4)) of this section, an individual has a right to adequate notice of the uses and disclosures of protected health information that may be made by the covered entity, and of the individual's rights and the covered entity's legal duties with respect to protected health information."
+                  "description": "Except as provided by paragraph (a)(3) or (4) of this section, an individual has a right to adequate notice of the uses and disclosures of protected health information that may be made by the covered entity, and of the individual's rights and the covered entity's legal duties with respect to protected health information."
                 },
                 {
                   "ref": "164.520(a)(2)",
-                  "label": "**Notice requirements for covered entities creating or maintaining records subject to **[**42 U.S.C. 290dd-2**](https://www.govinfo.gov/link/uscode/42/290dd-2)**.**",
-                  "description": "As provided in [42 CFR 2.22](https://www.ecfr.gov/current/title-42/section-2.22), an individual who is the subject of records protected under [42 CFR part 2](https://www.ecfr.gov/current/title-42/part-2) has a right to adequate notice of the uses and disclosures of such records, and of the individual's rights and the covered entity's legal duties with respect to such records."
+                  "label": "Notice requirements for covered entities creating or maintaining records subject to 42 U.S.C. 290dd-2.",
+                  "description": "As provided in 42 CFR 2.22, an individual who is the subject of records protected under 42 CFR part 2 has a right to adequate notice of the uses and disclosures of such records, and of the individual's rights and the covered entity's legal duties with respect to such records."
                 },
                 {
                   "ref": "164.520(a)(3)",
-                  "label": "***Exception for group health plans.***",
+                  "label": "Exception for group health plans.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.520(a)(3)(i)",
                       "label": "An individual enrolled in a group health plan has a right to notice:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.520(a)(3)(i)(A)",
@@ -3248,7 +3455,8 @@
                     },
                     {
                       "ref": "164.520(a)(3)(ii)",
-                      "label": "A group health plan that provides health benefits solely through an insurance contract with a health insurance issuer or HMO, and that creates or receives protected health information in addition to summary health information as defined in [§ 164.504(a)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(a)) or information on whether the individual is participating in the group health plan, or is enrolled in or has disenrolled from a health insurance issuer or HMO offered by the plan, must:",
+                      "label": "A group health plan that provides health benefits solely through an insurance contract with a health insurance issuer or HMO, and that creates or receives protected health information in addition to summary health information as defined in § 164.504(a) or information on whether the individual is participating in the group health plan, or is enrolled in or has disenrolled from a health insurance issuer or HMO offered by the plan, must:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.520(a)(3)(ii)(A)",
@@ -3256,13 +3464,13 @@
                         },
                         {
                           "ref": "164.520(a)(3)(ii)(B)",
-                          "label": "Provide such notice upon request to any person. The provisions of [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(1)) of this section do not apply to such group health plan."
+                          "label": "Provide such notice upon request to any person. The provisions of paragraph (c)(1) of this section do not apply to such group health plan."
                         }
                       ]
                     },
                     {
                       "ref": "164.520(a)(3)(iii)",
-                      "label": "A group health plan that provides health benefits solely through an insurance contract with a health insurance issuer or HMO, and does not create or receive protected health information other than summary health information as defined in [§ 164.504(a)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(a)) or information on whether an individual is participating in the group health plan, or is enrolled in or has disenrolled from a health insurance issuer or HMO offered by the plan, is not required to maintain or provide a notice under this section."
+                      "label": "A group health plan that provides health benefits solely through an insurance contract with a health insurance issuer or HMO, and does not create or receive protected health information other than summary health information as defined in § 164.504(a) or information on whether an individual is participating in the group health plan, or is enrolled in or has disenrolled from a health insurance issuer or HMO offered by the plan, is not required to maintain or provide a notice under this section."
                     }
                   ]
                 },
@@ -3275,12 +3483,14 @@
             },
             {
               "ref": "164.520(b)",
-              "label": "**Implementation specifications: Content of notice**",
+              "label": "Implementation specifications: Content of notice",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.520(b)(1)",
-                  "label": "**Required elements.**",
-                  "description": "The covered entity, including any covered entity receiving or maintaining records subject to [42 U.S.C. 290dd-2](https://www.govinfo.gov/link/uscode/42/290dd-2), must provide a notice that is written in plain language and that contains the elements required by this paragraph.",
+                  "label": "Required elements.",
+                  "description": "The covered entity, including any covered entity receiving or maintaining records subject to 42 U.S.C. 290dd-2, must provide a notice that is written in plain language and that contains the elements required by this paragraph.",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.520(b)(1)(i)",
@@ -3291,6 +3501,7 @@
                       "ref": "164.520(b)(1)(ii)",
                       "label": "Uses and disclosures.",
                       "description": "The notice must contain:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.520(b)(1)(ii)(A)",
@@ -3302,23 +3513,23 @@
                         },
                         {
                           "ref": "164.520(b)(1)(ii)(C)",
-                          "label": "If a use or disclosure for any purpose described in [paragraphs (b)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(ii)(A)) or [(B)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(ii)(B)) of this section is prohibited or materially limited by other applicable law, such as [42 CFR part 2](https://www.ecfr.gov/current/title-42/part-2), the description of such use or disclosure must reflect the more stringent law as defined in [§ 160.202 of this subchapter](https://www.ecfr.gov/current/title-45/section-160.202)."
+                          "label": "If a use or disclosure for any purpose described in paragraphs (b)(1)(ii)(A) or (B) of this section is prohibited or materially limited by other applicable law, such as 42 CFR part 2, the description of such use or disclosure must reflect the more stringent law as defined in § 160.202 of this subchapter."
                         },
                         {
                           "ref": "164.520(b)(1)(ii)(D)",
-                          "label": "For each purpose described in [paragraph (b)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(ii)(A)) or [(B)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(ii)(B)) of this section, the description must include sufficient detail to place the individual on notice of the uses and disclosures that are permitted or required by this subpart and other applicable law, such as [42 CFR part 2](https://www.ecfr.gov/current/title-42/part-2)."
+                          "label": "For each purpose described in paragraph (b)(1)(ii)(A) or (B) of this section, the description must include sufficient detail to place the individual on notice of the uses and disclosures that are permitted or required by this subpart and other applicable law, such as 42 CFR part 2."
                         },
                         {
                           "ref": "164.520(b)(1)(ii)(E)",
-                          "label": "A description of the types of uses and disclosures that require an authorization under [§ 164.508(a)(2)-(a)(4)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(a)(2)), a statement that other uses and disclosures not described in the notice will be made only with the individual's written authorization, and a statement that the individual may revoke an authorization as provided by [§ 164.508(b)(5)](https://www.ecfr.gov/current/title-45/section-164.508#p-164.508(b)(5))."
+                          "label": "A description of the types of uses and disclosures that require an authorization under § 164.508(a)(2)-(a)(4), a statement that other uses and disclosures not described in the notice will be made only with the individual's written authorization, and a statement that the individual may revoke an authorization as provided by § 164.508(b)(5)."
                         },
                         {
                           "ref": "164.520(b)(1)(ii)(F)",
-                          "label": "A description, including at least one example, of the types of uses and disclosures prohibited under [§ 164.502(a)(5)(iii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(5)(iii)) in sufficient detail for an individual to understand the prohibition."
+                          "label": "A description, including at least one example, of the types of uses and disclosures prohibited under § 164.502(a)(5)(iii) in sufficient detail for an individual to understand the prohibition."
                         },
                         {
                           "ref": "164.520(b)(1)(ii)(G)",
-                          "label": "A description, including at least one example, of the types of uses and disclosures for which an attestation is required under [§ 164.509](https://www.ecfr.gov/current/title-45/section-164.509)."
+                          "label": "A description, including at least one example, of the types of uses and disclosures for which an attestation is required under § 164.509."
                         },
                         {
                           "ref": "164.520(b)(1)(ii)(H)",
@@ -3329,27 +3540,28 @@
                     {
                       "ref": "164.520(b)(1)(iii)",
                       "label": "Separate statements for certain uses or disclosures",
-                      "description": "If the covered entity intends to engage in any of the following activities, the description required by [paragraph (b)(1)(ii)(A)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(ii)(A)) or [(B)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(ii)(B)) of this section must include a separate statement informing the individual of such activities, as applicable:",
+                      "description": "If the covered entity intends to engage in any of the following activities, the description required by paragraph (b)(1)(ii)(A) or (B) of this section must include a separate statement informing the individual of such activities, as applicable:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.520(b)(1)(iii)(A)",
-                          "label": "In accordance with [§ 164.514(f)(1)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(f)(1)), the covered entity may contact the individual to raise funds for the covered entity and the individual has a right to opt out of receiving such communications;"
+                          "label": "In accordance with § 164.514(f)(1), the covered entity may contact the individual to raise funds for the covered entity and the individual has a right to opt out of receiving such communications;"
                         },
                         {
                           "ref": "164.520(b)(1)(iii)(B)",
-                          "label": "In accordance with [§ 164.504(f)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)), the group health plan, or a health insurance issuer or HMO with respect to a group health plan, may disclose protected health information to the sponsor of the plan;"
+                          "label": "In accordance with § 164.504(f), the group health plan, or a health insurance issuer or HMO with respect to a group health plan, may disclose protected health information to the sponsor of the plan;"
                         },
                         {
                           "ref": "164.520(b)(1)(iii)(C)",
-                          "label": "If a covered entity that is a health plan, excluding an issuer of a long-term care policy falling within paragraph (1)(viii) of the definition of *health plan,* intends to use or disclose protected health information for underwriting purposes, a statement that the covered entity is prohibited from using or disclosing protected health information that is genetic information of an individual for such purposes;"
+                          "label": "If a covered entity that is a health plan, excluding an issuer of a long-term care policy falling within paragraph (1)(viii) of the definition of health plan, intends to use or disclose protected health information for underwriting purposes, a statement that the covered entity is prohibited from using or disclosing protected health information that is genetic information of an individual for such purposes;"
                         },
                         {
                           "ref": "164.520(b)(1)(iii)(D)",
-                          "label": "Substance use disorder treatment records received from programs subject to [42 CFR part 2](https://www.ecfr.gov/current/title-42/part-2), or testimony relaying the content of such records, shall not be used or disclosed in civil, criminal, administrative, or legislative proceedings against the individual unless based on written consent, or a court order after notice and an opportunity to be heard is provided to the individual or the holder of the record, as provided in [42 CFR part 2](https://www.ecfr.gov/current/title-42/part-2). A court order authorizing use or disclosure must be accompanied by a subpoena or other legal requirement compelling disclosure before the requested record is used or disclosed; or"
+                          "label": "Substance use disorder treatment records received from programs subject to 42 CFR part 2, or testimony relaying the content of such records, shall not be used or disclosed in civil, criminal, administrative, or legislative proceedings against the individual unless based on written consent, or a court order after notice and an opportunity to be heard is provided to the individual or the holder of the record, as provided in 42 CFR part 2. A court order authorizing use or disclosure must be accompanied by a subpoena or other legal requirement compelling disclosure before the requested record is used or disclosed; or"
                         },
                         {
                           "ref": "164.520(b)(1)(iii)(E)",
-                          "label": "If a covered entity that creates or maintains records subject to [42 CFR part 2](https://www.ecfr.gov/current/title-42/part-2) intends to use or disclose such records for fundraising for the benefit of the covered entity, the individual must first be provided with a clear and conspicuous opportunity to elect not to receive any fundraising communications."
+                          "label": "If a covered entity that creates or maintains records subject to 42 CFR part 2 intends to use or disclose such records for fundraising for the benefit of the covered entity, the individual must first be provided with a clear and conspicuous opportunity to elect not to receive any fundraising communications."
                         }
                       ]
                     },
@@ -3357,30 +3569,31 @@
                       "ref": "164.520(b)(1)(iv)",
                       "label": "Individual rights.",
                       "description": "The notice must contain a statement of the individual's rights with respect to protected health information and a brief description of how the individual may exercise these rights, as follows:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.520(b)(1)(iv)(A)",
-                          "label": "The right to request restrictions on certain uses and disclosures of protected health information as provided by [§ 164.522(a)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a)), including a statement that the covered entity is not required to agree to a requested restriction, except in case of a disclosure restricted under [§ 164.522(a)(1)(vi)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a)(1)(vi));"
+                          "label": "The right to request restrictions on certain uses and disclosures of protected health information as provided by § 164.522(a), including a statement that the covered entity is not required to agree to a requested restriction, except in case of a disclosure restricted under § 164.522(a)(1)(vi);"
                         },
                         {
                           "ref": "164.520(b)(1)(iv)(B)",
-                          "label": "The right to receive confidential communications of protected health information as provided by [§ 164.522(b)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(b)), as applicable;"
+                          "label": "The right to receive confidential communications of protected health information as provided by § 164.522(b), as applicable;"
                         },
                         {
                           "ref": "164.520(b)(1)(iv)(C)",
-                          "label": "The right to inspect and copy protected health information as provided by [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524);"
+                          "label": "The right to inspect and copy protected health information as provided by § 164.524;"
                         },
                         {
                           "ref": "164.520(b)(1)(iv)(D)",
-                          "label": "The right to amend protected health information as provided by [§ 164.526](https://www.ecfr.gov/current/title-45/section-164.526);"
+                          "label": "The right to amend protected health information as provided by § 164.526;"
                         },
                         {
                           "ref": "164.520(b)(1)(iv)(E)",
-                          "label": "The right to receive an accounting of disclosures of protected health information as provided by [§ 164.528](https://www.ecfr.gov/current/title-45/section-164.528); and"
+                          "label": "The right to receive an accounting of disclosures of protected health information as provided by § 164.528; and"
                         },
                         {
                           "ref": "164.520(b)(1)(iv)(F)",
-                          "label": "The right of an individual, including an individual who has agreed to receive the notice electronically in accordance with [paragraph (c)(3)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(3)) of this section, to obtain a paper copy of the notice from the covered entity upon request."
+                          "label": "The right of an individual, including an individual who has agreed to receive the notice electronically in accordance with paragraph (c)(3) of this section, to obtain a paper copy of the notice from the covered entity upon request."
                         }
                       ]
                     },
@@ -3388,6 +3601,7 @@
                       "ref": "164.520(b)(1)(v)",
                       "label": "Covered entity's duties.",
                       "description": "The notice must contain:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.520(b)(1)(v)(A)",
@@ -3399,7 +3613,7 @@
                         },
                         {
                           "ref": "164.520(b)(1)(v)(C)",
-                          "label": "For the covered entity to apply a change in a privacy practice that is described in the notice to protected health information that the covered entity created or received prior to issuing a revised notice, in accordance with [§ 164.530(i)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(i)(2)(ii)), a statement that it reserves the right to change the terms of its notice and to make the new notice provisions effective for all protected health information that it maintains. The statement must also describe how it will provide individuals with a revised notice."
+                          "label": "For the covered entity to apply a change in a privacy practice that is described in the notice to protected health information that the covered entity created or received prior to issuing a revised notice, in accordance with § 164.530(i)(2)(ii), a statement that it reserves the right to change the terms of its notice and to make the new notice provisions effective for all protected health information that it maintains. The statement must also describe how it will provide individuals with a revised notice."
                         }
                       ]
                     },
@@ -3411,11 +3625,11 @@
                     {
                       "ref": "164.520(b)(1)(vii)",
                       "label": "Contact.",
-                      "description": "The notice must contain the name, or title, and telephone number of a person or office to contact for further information as required by [§ 164.530(a)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(a)(1)(ii))."
+                      "description": "The notice must contain the name, or title, and telephone number of a person or office to contact for further information as required by § 164.530(a)(1)(ii)."
                     },
                     {
                       "ref": "164.520(b)(1)(viii)",
-                      "label": "**Effective date.**",
+                      "label": "Effective date.",
                       "description": "The notice must contain the date on which the notice is first in effect, which may not be earlier than the date on which the notice is printed or otherwise published."
                     }
                   ]
@@ -3423,14 +3637,15 @@
                 {
                   "ref": "164.520(b)(2)",
                   "label": "Optional elements.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.520(b)(2)(i)",
-                      "label": "In addition to the information required by [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)) of this section, if a covered entity elects to limit the uses or disclosures that it is permitted to make under this subpart, the covered entity may describe its more limited uses or disclosures in its notice, provided that the covered entity may not include in its notice a limitation affecting its right to make a use or disclosure that is required by law or permitted by [§ 164.512(j)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(j)(1)(i))."
+                      "label": "In addition to the information required by paragraph (b)(1) of this section, if a covered entity elects to limit the uses or disclosures that it is permitted to make under this subpart, the covered entity may describe its more limited uses or disclosures in its notice, provided that the covered entity may not include in its notice a limitation affecting its right to make a use or disclosure that is required by law or permitted by § 164.512(j)(1)(i)."
                     },
                     {
                       "ref": "164.520(b)(2)(ii)",
-                      "label": "For the covered entity to apply a change in its more limited uses and disclosures to protected health information created or received prior to issuing a revised notice, in accordance with [§ 164.530(i)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(i)(2)(ii)), the notice must include the statements required by [paragraph (b)(1)(v)(C)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(v)(C)) of this section."
+                      "label": "For the covered entity to apply a change in its more limited uses and disclosures to protected health information created or received prior to issuing a revised notice, in accordance with § 164.530(i)(2)(ii), the notice must include the statements required by paragraph (b)(1)(v)(C) of this section."
                     }
                   ]
                 },
@@ -3444,14 +3659,17 @@
             {
               "ref": "164.520(c)",
               "label": "Implementation specifications: Provision of notice",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.520(c)(1)",
                   "label": "Specific requirements for health plans.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.520(c)(1)(i)",
                       "label": "A health plan must provide the notice:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.520(c)(1)(i)(A)",
@@ -3469,23 +3687,24 @@
                     },
                     {
                       "ref": "164.520(c)(1)(iii)",
-                      "label": "The health plan satisfies the requirements of [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(1)) of this section if notice is provided to the named insured of a policy under which coverage is provided to the named insured and one or more dependents."
+                      "label": "The health plan satisfies the requirements of paragraph (c)(1) of this section if notice is provided to the named insured of a policy under which coverage is provided to the named insured and one or more dependents."
                     },
                     {
                       "ref": "164.520(c)(1)(iv)",
-                      "label": "If a health plan has more than one notice, it satisfies the requirements of [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(1)) of this section by providing the notice that is relevant to the individual or other person requesting the notice."
+                      "label": "If a health plan has more than one notice, it satisfies the requirements of paragraph (c)(1) of this section by providing the notice that is relevant to the individual or other person requesting the notice."
                     },
                     {
                       "ref": "164.520(c)(1)(v)",
                       "label": "If there is a material change to the notice:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.520(c)(1)(v)(A)",
-                          "label": "A health plan that posts its notice on its web site in accordance with [paragraph (c)(3)(i)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(3)(i)) of this section must prominently post the change or its revised notice on its web site by the effective date of the material change to the notice, and provide the revised notice, or information about the material change and how to obtain the revised notice, in its next annual mailing to individuals then covered by the plan."
+                          "label": "A health plan that posts its notice on its web site in accordance with paragraph (c)(3)(i) of this section must prominently post the change or its revised notice on its web site by the effective date of the material change to the notice, and provide the revised notice, or information about the material change and how to obtain the revised notice, in its next annual mailing to individuals then covered by the plan."
                         },
                         {
                           "ref": "164.520(c)(1)(v)(B)",
-                          "label": "A health plan that does not post its notice on a web site pursuant to [paragraph (c)(3)(i)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(3)(i)) of this section must provide the revised notice, or information about the material change and how to obtain the revised notice, to individuals then covered by the plan within 60 days of the material revision to the notice."
+                          "label": "A health plan that does not post its notice on a web site pursuant to paragraph (c)(3)(i) of this section must provide the revised notice, or information about the material change and how to obtain the revised notice, to individuals then covered by the plan within 60 days of the material revision to the notice."
                         }
                       ]
                     }
@@ -3495,10 +3714,12 @@
                   "ref": "164.520(c)(2)",
                   "label": "Specific requirements for certain covered health care providers.",
                   "description": "A covered health care provider that has a direct treatment relationship with an individual must:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.520(c)(2)(i)",
                       "label": "Provide the notice:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.520(c)(2)(i)(A)",
@@ -3512,11 +3733,12 @@
                     },
                     {
                       "ref": "164.520(c)(2)(ii)",
-                      "label": "Except in an emergency treatment situation, make a good faith effort to obtain a written acknowledgment of receipt of the notice provided in accordance with [paragraph (c)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(2)(i)) of this section, and if not obtained, document its good faith efforts to obtain such acknowledgment and the reason why the acknowledgment was not obtained;"
+                      "label": "Except in an emergency treatment situation, make a good faith effort to obtain a written acknowledgment of receipt of the notice provided in accordance with paragraph (c)(2)(i) of this section, and if not obtained, document its good faith efforts to obtain such acknowledgment and the reason why the acknowledgment was not obtained;"
                     },
                     {
                       "ref": "164.520(c)(2)(iii)",
                       "label": "If the covered health care provider maintains a physical service delivery site:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.520(c)(2)(iii)(A)",
@@ -3530,13 +3752,14 @@
                     },
                     {
                       "ref": "164.520(c)(2)(iv)",
-                      "label": "Whenever the notice is revised, make the notice available upon request on or after the effective date of the revision and promptly comply with the requirements of [paragraph (c)(2)(iii)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(2)(iii)) of this section, if applicable."
+                      "label": "Whenever the notice is revised, make the notice available upon request on or after the effective date of the revision and promptly comply with the requirements of paragraph (c)(2)(iii) of this section, if applicable."
                     }
                   ]
                 },
                 {
                   "ref": "164.520(c)(3)",
                   "label": "Specific requirements for electronic notice.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.520(c)(3)(i)",
@@ -3544,11 +3767,11 @@
                     },
                     {
                       "ref": "164.520(c)(3)(ii)",
-                      "label": "A covered entity may provide the notice required by this section to an individual by e-mail, if the individual agrees to electronic notice and such agreement has not been withdrawn. If the covered entity knows that the e-mail transmission has failed, a paper copy of the notice must be provided to the individual. Provision of electronic notice by the covered entity will satisfy the provision requirements of [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)) of this section when timely made in accordance with [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(1)) or [(2)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(2)) of this section."
+                      "label": "A covered entity may provide the notice required by this section to an individual by e-mail, if the individual agrees to electronic notice and such agreement has not been withdrawn. If the covered entity knows that the e-mail transmission has failed, a paper copy of the notice must be provided to the individual. Provision of electronic notice by the covered entity will satisfy the provision requirements of paragraph (c) of this section when timely made in accordance with paragraph (c)(1) or (2) of this section."
                     },
                     {
                       "ref": "164.520(c)(3)(iii)",
-                      "label": "For purposes of [paragraph (c)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(2)(i)) of this section, if the first service delivery to an individual is delivered electronically, the covered health care provider must provide electronic notice automatically and contemporaneously in response to the individual's first request for service. The requirements in [paragraph (c)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(2)(ii)) of this section apply to electronic notice."
+                      "label": "For purposes of paragraph (c)(2)(i) of this section, if the first service delivery to an individual is delivered electronically, the covered health care provider must provide electronic notice automatically and contemporaneously in response to the individual's first request for service. The requirements in paragraph (c)(2)(ii) of this section apply to electronic notice."
                     },
                     {
                       "ref": "164.520(c)(3)(iv)",
@@ -3562,6 +3785,7 @@
               "ref": "164.520(d)",
               "label": "Implementation specifications: Joint notice by separate covered entities.",
               "description": "Covered entities that participate in organized health care arrangements may comply with this section by a joint notice, provided that:",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.520(d)(1)",
@@ -3569,7 +3793,8 @@
                 },
                 {
                   "ref": "164.520(d)(2)",
-                  "label": "The joint notice meets the implementation specifications in [paragraph (b)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)) of this section, except that the statements required by this section may be altered to reflect the fact that the notice covers more than one covered entity; and",
+                  "label": "The joint notice meets the implementation specifications in paragraph (b) of this section, except that the statements required by this section may be altered to reflect the fact that the notice covers more than one covered entity; and",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.520(d)(2)(i)",
@@ -3587,35 +3812,39 @@
                 },
                 {
                   "ref": "164.520(d)(3)",
-                  "label": "The covered entities included in the joint notice must provide the notice to individuals in accordance with the applicable implementation specifications of [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)) of this section. Provision of the joint notice to an individual by any one of the covered entities included in the joint notice will satisfy the provision requirement of [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)) of this section with respect to all others covered by the joint notice."
+                  "label": "The covered entities included in the joint notice must provide the notice to individuals in accordance with the applicable implementation specifications of paragraph (c) of this section. Provision of the joint notice to an individual by any one of the covered entities included in the joint notice will satisfy the provision requirement of paragraph (c) of this section with respect to all others covered by the joint notice."
                 },
                 {
                   "ref": "164.520(d)(4)",
-                  "label": "The permission in [paragraph (d)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(d)) of this section for covered entities that participate in an organized health care arrangement to issue a joint notice may not be construed to remove any obligations or duties of entities creating or maintaining records subject to [42 U.S.C. 290dd-2](https://www.govinfo.gov/link/uscode/42/290dd-2), or to remove any rights of patients who are the subjects of such records."
+                  "label": "The permission in paragraph (d) of this section for covered entities that participate in an organized health care arrangement to issue a joint notice may not be construed to remove any obligations or duties of entities creating or maintaining records subject to 42 U.S.C. 290dd-2, or to remove any rights of patients who are the subjects of such records."
                 }
               ]
             },
             {
               "ref": "164.520(e)",
-              "label": "**Implementation specifications: Documentation.**",
-              "description": "A covered entity must document compliance with the notice requirements, as required by [§ 164.530(j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)), by retaining copies of the notices issued by the covered entity and, if applicable, any written acknowledgments of receipt of the notice or documentation of good faith efforts to obtain such written acknowledgment, in accordance with [paragraph (c)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)(2)(ii)) of this section."
+              "label": "Implementation specifications: Documentation.",
+              "description": "A covered entity must document compliance with the notice requirements, as required by § 164.530(j), by retaining copies of the notices issued by the covered entity and, if applicable, any written acknowledgments of receipt of the notice or documentation of good faith efforts to obtain such written acknowledgment, in accordance with paragraph (c)(2)(ii) of this section."
             }
           ]
         },
         {
           "ref": "164.522",
           "label": "Rights to request privacy protection for protected health information.",
+          "group": true,
           "controls": [
             {
               "ref": "164.522(a)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.522(a)(1)",
                   "label": "Standard: Right of an individual to request restriction of uses and disclosures",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.522(a)(1)(i)",
                       "label": "A covered entity must permit an individual to request that the covered entity restrict:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.522(a)(1)(i)(A)",
@@ -3623,29 +3852,30 @@
                         },
                         {
                           "ref": "164.522(a)(1)(i)(B)",
-                          "label": "Disclosures permitted under [§ 164.510(b)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(b))."
+                          "label": "Disclosures permitted under § 164.510(b)."
                         }
                       ]
                     },
                     {
                       "ref": "164.522(a)(1)(ii)",
-                      "label": "Except as provided in [paragraph (a)(1)(vi)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a)(1)(vi)) of this section, a covered entity is not required to agree to a restriction."
+                      "label": "Except as provided in paragraph (a)(1)(vi) of this section, a covered entity is not required to agree to a restriction."
                     },
                     {
                       "ref": "164.522(a)(1)(iii)",
-                      "label": "A covered entity that agrees to a restriction under [paragraph (a)(1)(i)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a)(1)(i)) of this section may not use or disclose protected health information in violation of such restriction, except that, if the individual who requested the restriction is in need of emergency treatment and the restricted protected health information is needed to provide the emergency treatment, the covered entity may use the restricted protected health information, or may disclose such information to a health care provider, to provide such treatment to the individual."
+                      "label": "A covered entity that agrees to a restriction under paragraph (a)(1)(i) of this section may not use or disclose protected health information in violation of such restriction, except that, if the individual who requested the restriction is in need of emergency treatment and the restricted protected health information is needed to provide the emergency treatment, the covered entity may use the restricted protected health information, or may disclose such information to a health care provider, to provide such treatment to the individual."
                     },
                     {
                       "ref": "164.522(a)(1)(iv)",
-                      "label": "If restricted protected health information is disclosed to a health care provider for emergency treatment under [paragraph (a)(1)(iii)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a)(1)(iii)) of this section, the covered entity must request that such health care provider not further use or disclose the information."
+                      "label": "If restricted protected health information is disclosed to a health care provider for emergency treatment under paragraph (a)(1)(iii) of this section, the covered entity must request that such health care provider not further use or disclose the information."
                     },
                     {
                       "ref": "164.522(a)(1)(v)",
-                      "label": "A restriction agreed to by a covered entity under [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a)) of this section, is not effective under this subpart to prevent uses or disclosures permitted or required under [§ 164.502(a)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(2)(ii)), [§ 164.510(a)](https://www.ecfr.gov/current/title-45/section-164.510#p-164.510(a)) or [§ 164.512](https://www.ecfr.gov/current/title-45/section-164.512)."
+                      "label": "A restriction agreed to by a covered entity under paragraph (a) of this section, is not effective under this subpart to prevent uses or disclosures permitted or required under § 164.502(a)(2)(ii), § 164.510(a) or § 164.512."
                     },
                     {
                       "ref": "164.522(a)(1)(vi)",
                       "label": "A covered entity must agree to the request of an individual to restrict disclosure of protected health information about the individual to a health plan if:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.522(a)(1)(vi)(A)",
@@ -3663,6 +3893,7 @@
                   "ref": "164.522(a)(2)",
                   "label": "Implementation specifications: Terminating a restriction",
                   "description": "A covered entity may terminate a restriction, if:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.522(a)(2)(i)",
@@ -3675,10 +3906,11 @@
                     {
                       "ref": "164.522(a)(2)(iii)",
                       "label": "The covered entity informs the individual that it is terminating its agreement to a restriction, except that such termination is:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.522(a)(2)(iii)(A)",
-                          "label": "Not effective for protected health information restricted under [paragraph (a)(1)(vi)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(a)(1)(vi)) of this section; and"
+                          "label": "Not effective for protected health information restricted under paragraph (a)(1)(vi) of this section; and"
                         },
                         {
                           "ref": "164.522(a)(2)(iii)(B)",
@@ -3690,17 +3922,19 @@
                 },
                 {
                   "ref": "164.522(a)(3)",
-                  "label": "**Implementation specification: Documentation.**",
-                  "description": "A covered entity must document a restriction in accordance with [§ 160.530(j) of this subchapter](https://www.ecfr.gov/current/title-45/section-160.530#p-160.530(j))."
+                  "label": "Implementation specification: Documentation.",
+                  "description": "A covered entity must document a restriction in accordance with § 160.530(j) of this subchapter."
                 }
               ]
             },
             {
               "ref": "164.522(b)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.522(b)(1)",
                   "label": "Standard: Confidential communications requirements.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.522(b)(1)(i)",
@@ -3714,15 +3948,17 @@
                 },
                 {
                   "ref": "164.522(b)(2)",
-                  "label": "**Implementation specifications: Conditions on providing confidential communications.**",
+                  "label": "Implementation specifications: Conditions on providing confidential communications.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.522(b)(2)(i)",
-                      "label": "A covered entity may require the individual to make a request for a confidential communication described in [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.522#p-164.522(b)(1)) of this section in writing."
+                      "label": "A covered entity may require the individual to make a request for a confidential communication described in paragraph (b)(1) of this section in writing."
                     },
                     {
                       "ref": "164.522(b)(2)(ii)",
                       "label": "covered entity may condition the provision of a reasonable accommodation on:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.522(b)(2)(ii)(A)",
@@ -3751,15 +3987,18 @@
         {
           "ref": "164.524",
           "label": "Access of individuals to protected health information.",
+          "group": true,
           "controls": [
             {
               "ref": "164.524(a)",
-              "label": "**Standard: Access to protected health information**",
+              "label": "Standard: Access to protected health information",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.524(a)(1)",
                   "label": "Right of access",
-                  "description": "Except as otherwise provided in [paragraph (a)(2)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(a)(2)) or [(a)(3)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(a)(3)) of this section, an individual has a right of access to inspect and obtain a copy of protected health information about the individual in a designated record set, for as long as the protected health information is maintained in the designated record set, except for:",
+                  "description": "Except as otherwise provided in paragraph (a)(2) or (a)(3) of this section, an individual has a right of access to inspect and obtain a copy of protected health information about the individual in a designated record set, for as long as the protected health information is maintained in the designated record set, except for:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.524(a)(1)(i)",
@@ -3775,10 +4014,11 @@
                   "ref": "164.524(a)(2)",
                   "label": "Unreviewable grounds for denial.",
                   "description": "A covered entity may deny an individual access without providing the individual an opportunity for review, in the following circumstances.",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.524(a)(2)(i)",
-                      "label": "The protected health information is excepted from the right of access by [paragraph (a)(1)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(a)(1)) of this section"
+                      "label": "The protected health information is excepted from the right of access by paragraph (a)(1) of this section"
                     },
                     {
                       "ref": "164.524(a)(2)(ii)",
@@ -3790,7 +4030,7 @@
                     },
                     {
                       "ref": "164.524(a)(2)(iv)",
-                      "label": "An individual's access to protected health information that is contained in records that are subject to the Privacy Act, [5 U.S.C. 552a](https://www.govinfo.gov/link/uscode/5/552a), may be denied, if the denial of access under the Privacy Act would meet the requirements of that law."
+                      "label": "An individual's access to protected health information that is contained in records that are subject to the Privacy Act, 5 U.S.C. 552a, may be denied, if the denial of access under the Privacy Act would meet the requirements of that law."
                     },
                     {
                       "ref": "164.524(a)(2)(v)",
@@ -3800,8 +4040,9 @@
                 },
                 {
                   "ref": "164.524(a)(3)",
-                  "label": "**Reviewable grounds for denial.**",
-                  "description": "A covered entity may deny an individual access, provided that the individual is given a right to have such denials reviewed, as required by [paragraph (a)(4)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(a)(4)) of this section, in the following circumstances:",
+                  "label": "Reviewable grounds for denial.",
+                  "description": "A covered entity may deny an individual access, provided that the individual is given a right to have such denials reviewed, as required by paragraph (a)(4) of this section, in the following circumstances:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.524(a)(3)(i)",
@@ -3820,13 +4061,14 @@
                 {
                   "ref": "164.524(a)(4)",
                   "label": "Review of a denial of access",
-                  "description": "If access is denied on a ground permitted under [paragraph (a)(3)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(a)(3)) of this section, the individual has the right to have the denial reviewed by a licensed health care professional who is designated by the covered entity to act as a reviewing official and who did not participate in the original decision to deny. The covered entity must provide or deny access in accordance with the determination of the reviewing official under [paragraph (d)(4)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(d)(4)) of this section."
+                  "description": "If access is denied on a ground permitted under paragraph (a)(3) of this section, the individual has the right to have the denial reviewed by a licensed health care professional who is designated by the covered entity to act as a reviewing official and who did not participate in the original decision to deny. The covered entity must provide or deny access in accordance with the determination of the reviewing official under paragraph (d)(4) of this section."
                 }
               ]
             },
             {
               "ref": "164.524(b)",
               "label": "Implementation specifications: Requests for access and timely action",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.524(b)(1)",
@@ -3836,28 +4078,31 @@
                 {
                   "ref": "164.524(b)(2)",
                   "label": "Timely action by the covered entity.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.524(b)(2)(i)",
-                      "label": "Except as provided in [paragraph (b)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(b)(2)(ii)) of this section, the covered entity must act on a request for access no later than 30 days after receipt of the request as follows.",
+                      "label": "Except as provided in paragraph (b)(2)(ii) of this section, the covered entity must act on a request for access no later than 30 days after receipt of the request as follows.",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.524(b)(2)(i)(A)",
-                          "label": "If the covered entity grants the request, in whole or in part, it must inform the individual of the acceptance of the request and provide the access requested, in accordance with [paragraph (c)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(c)) of this section."
+                          "label": "If the covered entity grants the request, in whole or in part, it must inform the individual of the acceptance of the request and provide the access requested, in accordance with paragraph (c) of this section."
                         },
                         {
                           "ref": "164.524(b)(2)(i)(B)",
-                          "label": "If the covered entity denies the request, in whole or in part, it must provide the individual with a written denial, in accordance with [paragraph (d)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(d)) of this section."
+                          "label": "If the covered entity denies the request, in whole or in part, it must provide the individual with a written denial, in accordance with paragraph (d) of this section."
                         }
                       ]
                     },
                     {
                       "ref": "164.524(b)(2)(ii)",
-                      "label": "If the covered entity is unable to take an action required by [paragraph (b)(2)(i)(A)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(b)(2)(i)(A)) or [(B)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(b)(2)(i)(B)) of this section within the time required by [paragraph (b)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(b)(2)(i)) of this section, as applicable, the covered entity may extend the time for such actions by no more than 30 days, provided that:",
+                      "label": "If the covered entity is unable to take an action required by paragraph (b)(2)(i)(A) or (B) of this section within the time required by paragraph (b)(2)(i) of this section, as applicable, the covered entity may extend the time for such actions by no more than 30 days, provided that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.524(b)(2)(ii)(A)",
-                          "label": "The covered entity, within the time limit set by [paragraph (b)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(b)(2)(i)) of this section, as applicable, provides the individual with a written statement of the reasons for the delay and the date by which the covered entity will complete its action on the request; and"
+                          "label": "The covered entity, within the time limit set by paragraph (b)(2)(i) of this section, as applicable, provides the individual with a written statement of the reasons for the delay and the date by which the covered entity will complete its action on the request; and"
                         },
                         {
                           "ref": "164.524(b)(2)(ii)(B)",
@@ -3873,6 +4118,7 @@
               "ref": "164.524(c)",
               "label": "Implementation specifications: Provision of access.",
               "description": "If the covered entity provides an individual with access, in whole or in part, to protected health information, the covered entity must comply with the following requirements.",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.524(c)(1)",
@@ -3882,6 +4128,7 @@
                 {
                   "ref": "164.524(c)(2)",
                   "label": "Form of access requested.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.524(c)(2)(i)",
@@ -3889,11 +4136,12 @@
                     },
                     {
                       "ref": "164.524(c)(2)(ii)",
-                      "label": "Notwithstanding [paragraph (c)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(c)(2)(i)) of this section, if the protected health information that is the subject of a request for access is maintained in one or more designated record sets electronically and if the individual requests an electronic copy of such information, the covered entity must provide the individual with access to the protected health information in the electronic form and format requested by the individual, if it is readily producible in such form and format; or, if not, in a readable electronic form and format as agreed to by the covered entity and the individual."
+                      "label": "Notwithstanding paragraph (c)(2)(i) of this section, if the protected health information that is the subject of a request for access is maintained in one or more designated record sets electronically and if the individual requests an electronic copy of such information, the covered entity must provide the individual with access to the protected health information in the electronic form and format requested by the individual, if it is readily producible in such form and format; or, if not, in a readable electronic form and format as agreed to by the covered entity and the individual."
                     },
                     {
                       "ref": "164.524(c)(2)(iii)",
                       "label": "The covered entity may provide the individual with a summary of the protected health information requested, in lieu of providing access to the protected health information or may provide an explanation of the protected health information to which access has been provided, if:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.524(c)(2)(iii)(A)",
@@ -3910,10 +4158,11 @@
                 {
                   "ref": "164.524(c)(3)",
                   "label": "Time and manner of access.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.524(c)(3)(i)",
-                      "label": "The covered entity must provide the access as requested by the individual in a timely manner as required by [paragraph (b)(2)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(b)(2)) of this section, including arranging with the individual for a convenient time and place to inspect or obtain a copy of the protected health information, or mailing the copy of the protected health information at the individual's request. The covered entity may discuss the scope, format, and other aspects of the request for access with the individual as necessary to facilitate the timely provision of access."
+                      "label": "The covered entity must provide the access as requested by the individual in a timely manner as required by paragraph (b)(2) of this section, including arranging with the individual for a convenient time and place to inspect or obtain a copy of the protected health information, or mailing the copy of the protected health information at the individual's request. The covered entity may discuss the scope, format, and other aspects of the request for access with the individual as necessary to facilitate the timely provision of access."
                     },
                     {
                       "ref": "164.524(c)(3)(ii)",
@@ -3925,6 +4174,7 @@
                   "ref": "164.524(c)(4)",
                   "label": "Fees",
                   "description": "If the individual requests a copy of the protected health information or agrees to a summary or explanation of such information, the covered entity may impose a reasonable, cost-based fee, provided that the fee includes only the cost of:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.524(c)(4)(i)",
@@ -3940,7 +4190,7 @@
                     },
                     {
                       "ref": "164.524(c)(4)(iv)",
-                      "label": "Preparing an explanation or summary of the protected health information, if agreed to by the individual as required by [paragraph (c)(2)(iii)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(c)(2)(iii)) of this section."
+                      "label": "Preparing an explanation or summary of the protected health information, if agreed to by the individual as required by paragraph (c)(2)(iii) of this section."
                     }
                   ]
                 }
@@ -3950,6 +4200,7 @@
               "ref": "164.524(d)",
               "label": "Implementation specifications: Denial of access",
               "description": "If the covered entity denies access, in whole or in part, to protected health information, the covered entity must comply with the following requirements.",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.524(d)(1)",
@@ -3959,7 +4210,8 @@
                 {
                   "ref": "164.524(d)(2)",
                   "label": "Denial.",
-                  "description": "The covered entity must provide a timely, written denial to the individual, in accordance with [paragraph (b)(2)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(b)(2)) of this section. The denial must be in plain language and contain:",
+                  "description": "The covered entity must provide a timely, written denial to the individual, in accordance with paragraph (b)(2) of this section. The denial must be in plain language and contain:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.524(d)(2)(i)",
@@ -3967,11 +4219,11 @@
                     },
                     {
                       "ref": "164.524(d)(2)(ii)",
-                      "label": "If applicable, a statement of the individual's review rights under [paragraph (a)(4)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(a)(4)) of this section, including a description of how the individual may exercise such review rights; and"
+                      "label": "If applicable, a statement of the individual's review rights under paragraph (a)(4) of this section, including a description of how the individual may exercise such review rights; and"
                     },
                     {
                       "ref": "164.524(d)(2)(iii)",
-                      "label": "A description of how the individual may complain to the covered entity pursuant to the complaint procedures in [§ 164.530(d)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(d)) or to the Secretary pursuant to the procedures in [§ 160.306](https://www.ecfr.gov/current/title-45/section-160.306). The description must include the name, or title, and telephone number of the contact person or office designated in [§ 164.530(a)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(a)(1)(ii))."
+                      "label": "A description of how the individual may complain to the covered entity pursuant to the complaint procedures in § 164.530(d) or to the Secretary pursuant to the procedures in § 160.306. The description must include the name, or title, and telephone number of the contact person or office designated in § 164.530(a)(1)(ii)."
                     }
                   ]
                 },
@@ -3982,15 +4234,16 @@
                 },
                 {
                   "ref": "164.524(d)(4)",
-                  "label": "**Review of denial requested.**",
-                  "description": "If the individual has requested a review of a denial under [paragraph (a)(4)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(a)(4)) of this section, the covered entity must designate a licensed health care professional, who was not directly involved in the denial to review the decision to deny access. The covered entity must promptly refer a request for review to such designated reviewing official. The designated reviewing official must determine, within a reasonable period of time, whether or not to deny the access requested based on the standards in [paragraph (a)(3)](https://www.ecfr.gov/current/title-45/section-164.524#p-164.524(a)(3)) of this section. The covered entity must promptly provide written notice to the individual of the determination of the designated reviewing official and take other action as required by this section to carry out the designated reviewing official's determination."
+                  "label": "Review of denial requested.",
+                  "description": "If the individual has requested a review of a denial under paragraph (a)(4) of this section, the covered entity must designate a licensed health care professional, who was not directly involved in the denial to review the decision to deny access. The covered entity must promptly refer a request for review to such designated reviewing official. The designated reviewing official must determine, within a reasonable period of time, whether or not to deny the access requested based on the standards in paragraph (a)(3) of this section. The covered entity must promptly provide written notice to the individual of the determination of the designated reviewing official and take other action as required by this section to carry out the designated reviewing official's determination."
                 }
               ]
             },
             {
               "ref": "164.524(e)",
               "label": "Implementation specification: Documentation",
-              "description": "A covered entity must document the following and retain the documentation as required by [§ 164.530(j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)):",
+              "description": "A covered entity must document the following and retain the documentation as required by § 164.530(j):",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.524(e)(1)",
@@ -4007,10 +4260,12 @@
         {
           "ref": "164.526",
           "label": "Amendment of protected health information.",
+          "group": true,
           "controls": [
             {
               "ref": "164.526(a)",
               "label": "Standard: Right to amend.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.526(a)(1)",
@@ -4021,6 +4276,7 @@
                   "ref": "164.526(a)(2)",
                   "label": "Denial of amendment.",
                   "description": "A covered entity may deny an individual's request for amendment, if it determines that the protected health information or record that is the subject of the request:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.526(a)(2)(i)",
@@ -4032,7 +4288,7 @@
                     },
                     {
                       "ref": "164.526(a)(2)(iii)",
-                      "label": "Would not be available for inspection under [§ 164.524](https://www.ecfr.gov/current/title-45/section-164.524); or"
+                      "label": "Would not be available for inspection under § 164.524; or"
                     },
                     {
                       "ref": "164.526(a)(2)(iv)",
@@ -4044,7 +4300,8 @@
             },
             {
               "ref": "164.526(b)",
-              "label": "**Implementation specifications: Requests for amendment and timely action**",
+              "label": "Implementation specifications: Requests for amendment and timely action",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.526(b)(1)",
@@ -4054,28 +4311,31 @@
                 {
                   "ref": "164.526(b)(2)",
                   "label": "Timely action by the covered entity.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.526(b)(2)(i)",
                       "label": "The covered entity must act on the individual's request for an amendment no later than 60 days after receipt of such a request, as follows.",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.526(b)(2)(i)(A)",
-                          "label": "If the covered entity grants the requested amendment, in whole or in part, it must take the actions required by [paragraphs (c)(1)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(c)(1)) and [(2)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(c)(2)) of this section."
+                          "label": "If the covered entity grants the requested amendment, in whole or in part, it must take the actions required by paragraphs (c)(1) and (2) of this section."
                         },
                         {
                           "ref": "164.526(b)(2)(i)(B)",
-                          "label": "If the covered entity denies the requested amendment, in whole or in part, it must provide the individual with a written denial, in accordance with [paragraph (d)(1)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(d)(1)) of this section."
+                          "label": "If the covered entity denies the requested amendment, in whole or in part, it must provide the individual with a written denial, in accordance with paragraph (d)(1) of this section."
                         }
                       ]
                     },
                     {
                       "ref": "164.526(b)(2)(ii)",
-                      "label": "If the covered entity is unable to act on the amendment within the time required by [paragraph (b)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(b)(2)(i)) of this section, the covered entity may extend the time for such action by no more than 30 days, provided that:",
+                      "label": "If the covered entity is unable to act on the amendment within the time required by paragraph (b)(2)(i) of this section, the covered entity may extend the time for such action by no more than 30 days, provided that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.526(b)(2)(ii)(A)",
-                          "label": "The covered entity, within the time limit set by [paragraph (b)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(b)(2)(i)) of this section, provides the individual with a written statement of the reasons for the delay and the date by which the covered entity will complete its action on the request; and"
+                          "label": "The covered entity, within the time limit set by paragraph (b)(2)(i) of this section, provides the individual with a written statement of the reasons for the delay and the date by which the covered entity will complete its action on the request; and"
                         },
                         {
                           "ref": "164.526(b)(2)(ii)(B)",
@@ -4091,6 +4351,7 @@
               "ref": "164.526(c)",
               "label": "Implementation specifications: Accepting the amendment",
               "description": "If the covered entity accepts the requested amendment, in whole or in part, the covered entity must comply with the following requirements.",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.526(c)(1)",
@@ -4099,13 +4360,14 @@
                 },
                 {
                   "ref": "164.526(c)(2)",
-                  "label": "**Informing the individual.**",
-                  "description": "In accordance with [paragraph (b)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(b)) of this section, the covered entity must timely inform the individual that the amendment is accepted and obtain the individual's identification of and agreement to have the covered entity notify the relevant persons with which the amendment needs to be shared in accordance with [paragraph (c)(3)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(c)(3)) of this section."
+                  "label": "Informing the individual.",
+                  "description": "In accordance with paragraph (b) of this section, the covered entity must timely inform the individual that the amendment is accepted and obtain the individual's identification of and agreement to have the covered entity notify the relevant persons with which the amendment needs to be shared in accordance with paragraph (c)(3) of this section."
                 },
                 {
                   "ref": "164.526(c)(3)",
                   "label": "Informing others.",
                   "description": "The covered entity must make reasonable efforts to inform and provide the amendment within a reasonable time to:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.526(c)(3)(i)",
@@ -4123,15 +4385,17 @@
               "ref": "164.526(d)",
               "label": "Implementation specifications: Denying the amendment.",
               "description": "If the covered entity denies the requested amendment, in whole or in part, the covered entity must comply with the following requirements.",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.526(d)(1)",
                   "label": "Denial.",
-                  "description": "The covered entity must provide the individual with a timely, written denial, in accordance with [paragraph (b)(2)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(b)(2)) of this section. The denial must use plain language and contain:",
+                  "description": "The covered entity must provide the individual with a timely, written denial, in accordance with paragraph (b)(2) of this section. The denial must use plain language and contain:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.526(d)(1)(i)",
-                      "label": "The basis for the denial, in accordance with [paragraph (a)(2)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(a)(2)) of this section;"
+                      "label": "The basis for the denial, in accordance with paragraph (a)(2) of this section;"
                     },
                     {
                       "ref": "164.526(d)(1)(ii)",
@@ -4143,7 +4407,7 @@
                     },
                     {
                       "ref": "164.526(d)(1)(iv)",
-                      "label": "A description of how the individual may complain to the covered entity pursuant to the complaint procedures established in [§ 164.530(d)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(d)) or to the Secretary pursuant to the procedures established in [§ 160.306](https://www.ecfr.gov/current/title-45/section-160.306). The description must include the name, or title, and telephone number of the contact person or office designated in [§ 164.530(a)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(a)(1)(ii))."
+                      "label": "A description of how the individual may complain to the covered entity pursuant to the complaint procedures established in § 164.530(d) or to the Secretary pursuant to the procedures established in § 160.306. The description must include the name, or title, and telephone number of the contact person or office designated in § 164.530(a)(1)(ii)."
                     }
                   ]
                 },
@@ -4164,19 +4428,20 @@
                 },
                 {
                   "ref": "164.526(d)(5)",
-                  "label": "**Future disclosures.**",
+                  "label": "Future disclosures.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.526(d)(5)(i)",
-                      "label": "If a statement of disagreement has been submitted by the individual, the covered entity must include the material appended in accordance with [paragraph (d)(4)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(d)(4)) of this section, or, at the election of the covered entity, an accurate summary of any such information, with any subsequent disclosure of the protected health information to which the disagreement relates."
+                      "label": "If a statement of disagreement has been submitted by the individual, the covered entity must include the material appended in accordance with paragraph (d)(4) of this section, or, at the election of the covered entity, an accurate summary of any such information, with any subsequent disclosure of the protected health information to which the disagreement relates."
                     },
                     {
                       "ref": "164.526(d)(5)(ii)",
-                      "label": "If the individual has not submitted a written statement of disagreement, the covered entity must include the individual's request for amendment and its denial, or an accurate summary of such information, with any subsequent disclosure of the protected health information only if the individual has requested such action in accordance with [paragraph (d)(1)(iii)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(d)(1)(iii)) of this section."
+                      "label": "If the individual has not submitted a written statement of disagreement, the covered entity must include the individual's request for amendment and its denial, or an accurate summary of such information, with any subsequent disclosure of the protected health information only if the individual has requested such action in accordance with paragraph (d)(1)(iii) of this section."
                     },
                     {
                       "ref": "164.526(d)(5)(iii)",
-                      "label": "When a subsequent disclosure described in [paragraph (d)(5)(i)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(d)(5)(i)) or [(ii)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(d)(5)(ii)) of this section is made using a standard transaction under part 162 of this subchapter that does not permit the additional material to be included with the disclosure, the covered entity may separately transmit the material required by [paragraph (d)(5)(i)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(d)(5)(i)) or [(ii)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(d)(5)(ii)) of this section, as applicable, to the recipient of the standard transaction."
+                      "label": "When a subsequent disclosure described in paragraph (d)(5)(i) or (ii) of this section is made using a standard transaction under part 162 of this subchapter that does not permit the additional material to be included with the disclosure, the covered entity may separately transmit the material required by paragraph (d)(5)(i) or (ii) of this section, as applicable, to the recipient of the standard transaction."
                     }
                   ]
                 }
@@ -4185,42 +4450,45 @@
             {
               "ref": "164.526(e)",
               "label": "Implementation specification: Actions on notices of amendment.",
-              "description": "A covered entity that is informed by another covered entity of an amendment to an individual's protected health information, in accordance with [paragraph (c)(3)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(c)(3)) of this section, must amend the protected health information in designated record sets as provided by [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.526#p-164.526(c)(1)) of this section."
+              "description": "A covered entity that is informed by another covered entity of an amendment to an individual's protected health information, in accordance with paragraph (c)(3) of this section, must amend the protected health information in designated record sets as provided by paragraph (c)(1) of this section."
             },
             {
               "ref": "164.526(f)",
-              "label": "**Implementation specification: Documentation.**",
-              "description": "A covered entity must document the titles of the persons or offices responsible for receiving and processing requests for amendments by individuals and retain the documentation as required by [§ 164.530(j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j))."
+              "label": "Implementation specification: Documentation.",
+              "description": "A covered entity must document the titles of the persons or offices responsible for receiving and processing requests for amendments by individuals and retain the documentation as required by § 164.530(j)."
             }
           ]
         },
         {
           "ref": "164.528",
           "label": "Accounting of disclosures of protected health information.",
+          "group": true,
           "controls": [
             {
               "ref": "164.528(a)",
               "label": "Standard: Right to an accounting of disclosures of protected health information",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.528(a)(1)",
                   "label": "An individual has a right to receive an accounting of disclosures of protected health information made by a covered entity in the six years prior to the date on which the accounting is requested, except for disclosures:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.528(a)(1)(i)",
-                      "label": "To carry out treatment, payment and health care operations as provided in [§ 164.506](https://www.ecfr.gov/current/title-45/section-164.506);"
+                      "label": "To carry out treatment, payment and health care operations as provided in § 164.506;"
                     },
                     {
                       "ref": "164.528(a)(1)(ii)",
-                      "label": "To individuals of protected health information about them as provided in [§ 164.502](https://www.ecfr.gov/current/title-45/section-164.502);"
+                      "label": "To individuals of protected health information about them as provided in § 164.502;"
                     },
                     {
                       "ref": "164.528(a)(1)(iii)",
-                      "label": "Incident to a use or disclosure otherwise permitted or required by this subpart, as provided in [§ 164.502](https://www.ecfr.gov/current/title-45/section-164.502);"
+                      "label": "Incident to a use or disclosure otherwise permitted or required by this subpart, as provided in § 164.502;"
                     },
                     {
                       "ref": "164.528(a)(1)(iv)",
-                      "label": "Pursuant to an authorization as provided in [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508);"
+                      "label": "Pursuant to an authorization as provided in § 164.508;"
                     },
                     {
                       "ref": "164.528(a)(1)(ix)",
@@ -4228,32 +4496,34 @@
                     },
                     {
                       "ref": "164.528(a)(1)(v)",
-                      "label": "For the facility's directory or to persons involved in the individual's care or other notification purposes as provided in [§ 164.510](https://www.ecfr.gov/current/title-45/section-164.510);"
+                      "label": "For the facility's directory or to persons involved in the individual's care or other notification purposes as provided in § 164.510;"
                     },
                     {
                       "ref": "164.528(a)(1)(vi)",
-                      "label": "For national security or intelligence purposes as provided in [§ 164.512(k)(2)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(k)(2));"
+                      "label": "For national security or intelligence purposes as provided in § 164.512(k)(2);"
                     },
                     {
                       "ref": "164.528(a)(1)(vii)",
-                      "label": "To correctional institutions or law enforcement officials as provided in [§ 164.512(k)(5)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(k)(5));"
+                      "label": "To correctional institutions or law enforcement officials as provided in § 164.512(k)(5);"
                     },
                     {
                       "ref": "164.528(a)(1)(viii)",
-                      "label": "As part of a limited data set in accordance with [§ 164.514(e)](https://www.ecfr.gov/current/title-45/section-164.514#p-164.514(e)); or"
+                      "label": "As part of a limited data set in accordance with § 164.514(e); or"
                     }
                   ]
                 },
                 {
                   "ref": "164.528(a)(2)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.528(a)(2)(i)",
-                      "label": "The covered entity must temporarily suspend an individual's right to receive an accounting of disclosures to a health oversight agency or law enforcement official, as provided in [§ 164.512(d)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(d)) or [(f)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(f)), respectively, for the time specified by such agency or official, if such agency or official provides the covered entity with a written statement that such an accounting to the individual would be reasonably likely to impede the agency's activities and specifying the time for which such a suspension is required."
+                      "label": "The covered entity must temporarily suspend an individual's right to receive an accounting of disclosures to a health oversight agency or law enforcement official, as provided in § 164.512(d) or (f), respectively, for the time specified by such agency or official, if such agency or official provides the covered entity with a written statement that such an accounting to the individual would be reasonably likely to impede the agency's activities and specifying the time for which such a suspension is required."
                     },
                     {
                       "ref": "164.528(a)(2)(ii)",
-                      "label": "If the agency or official statement in [paragraph (a)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(a)(2)(i)) of this section is made orally, the covered entity must:",
+                      "label": "If the agency or official statement in paragraph (a)(2)(i) of this section is made orally, the covered entity must:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.528(a)(2)(ii)(A)",
@@ -4265,7 +4535,7 @@
                         },
                         {
                           "ref": "164.528(a)(2)(ii)(C)",
-                          "label": "Limit the temporary suspension to no longer than 30 days from the date of the oral statement, unless a written statement pursuant to [paragraph (a)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(a)(2)(i)) of this section is submitted during that time."
+                          "label": "Limit the temporary suspension to no longer than 30 days from the date of the oral statement, unless a written statement pursuant to paragraph (a)(2)(i) of this section is submitted during that time."
                         }
                       ]
                     }
@@ -4281,14 +4551,16 @@
               "ref": "164.528(b)",
               "label": "Implementation specifications: Content of the accounting.",
               "description": "The covered entity must provide the individual with a written accounting that meets the following requirements.",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.528(b)(1)",
-                  "label": "Except as otherwise provided by [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(a)) of this section, the accounting must include disclosures of protected health information that occurred during the six years (or such shorter time period at the request of the individual as provided in [paragraph (a)(3)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(a)(3)) of this section) prior to the date of the request for an accounting, including disclosures to or by business associates of the covered entity."
+                  "label": "Except as otherwise provided by paragraph (a) of this section, the accounting must include disclosures of protected health information that occurred during the six years (or such shorter time period at the request of the individual as provided in paragraph (a)(3) of this section) prior to the date of the request for an accounting, including disclosures to or by business associates of the covered entity."
                 },
                 {
                   "ref": "164.528(b)(2)",
-                  "label": "Except as otherwise provided by [paragraphs (b)(3)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(b)(3)) or [(b)(4)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(b)(4)) of this section, the accounting must include for each disclosure:",
+                  "label": "Except as otherwise provided by paragraphs (b)(3) or (b)(4) of this section, the accounting must include for each disclosure:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.528(b)(2)(i)",
@@ -4304,17 +4576,18 @@
                     },
                     {
                       "ref": "164.528(b)(2)(iv)",
-                      "label": "A brief statement of the purpose of the disclosure that reasonably informs the individual of the basis for the disclosure or, in lieu of such statement, a copy of a written request for a disclosure under [§ 164.502(a)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(2)(ii)) or [§ 164.512](https://www.ecfr.gov/current/title-45/section-164.512), if any."
+                      "label": "A brief statement of the purpose of the disclosure that reasonably informs the individual of the basis for the disclosure or, in lieu of such statement, a copy of a written request for a disclosure under § 164.502(a)(2)(ii) or § 164.512, if any."
                     }
                   ]
                 },
                 {
                   "ref": "164.528(b)(3)",
-                  "label": "If, during the period covered by the accounting, the covered entity has made multiple disclosures of protected health information to the same person or entity for a single purpose under [§ 164.502(a)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(a)(2)(ii)) or [§ 164.512](https://www.ecfr.gov/current/title-45/section-164.512), the accounting may, with respect to such multiple disclosures, provide:",
+                  "label": "If, during the period covered by the accounting, the covered entity has made multiple disclosures of protected health information to the same person or entity for a single purpose under § 164.502(a)(2)(ii) or § 164.512, the accounting may, with respect to such multiple disclosures, provide:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.528(b)(3)(i)",
-                      "label": "The information required by [paragraph (b)(2)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(b)(2)) of this section for the first disclosure during the accounting period;"
+                      "label": "The information required by paragraph (b)(2) of this section for the first disclosure during the accounting period;"
                     },
                     {
                       "ref": "164.528(b)(3)(ii)",
@@ -4328,10 +4601,12 @@
                 },
                 {
                   "ref": "164.528(b)(4)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.528(b)(4)(i)",
-                      "label": "If, during the period covered by the accounting, the covered entity has made disclosures of protected health information for a particular research purpose in accordance with [§ 164.512(i)](https://www.ecfr.gov/current/title-45/section-164.512#p-164.512(i)) for 50 or more individuals, the accounting may, with respect to such disclosures for which the protected health information about the individual may have been included, provide:",
+                      "label": "If, during the period covered by the accounting, the covered entity has made disclosures of protected health information for a particular research purpose in accordance with § 164.512(i) for 50 or more individuals, the accounting may, with respect to such disclosures for which the protected health information about the individual may have been included, provide:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.528(b)(4)(i)(A)",
@@ -4361,7 +4636,7 @@
                     },
                     {
                       "ref": "164.528(b)(4)(ii)",
-                      "label": "If the covered entity provides an accounting for research disclosures, in accordance with [paragraph (b)(4)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(b)(4)) of this section, and if it is reasonably likely that the protected health information of the individual was disclosed for such research protocol or activity, the covered entity shall, at the request of the individual, assist in contacting the entity that sponsored the research and the researcher."
+                      "label": "If the covered entity provides an accounting for research disclosures, in accordance with paragraph (b)(4) of this section, and if it is reasonably likely that the protected health information of the individual was disclosed for such research protocol or activity, the covered entity shall, at the request of the individual, assist in contacting the entity that sponsored the research and the researcher."
                     }
                   ]
                 }
@@ -4370,10 +4645,12 @@
             {
               "ref": "164.528(c)",
               "label": "Implementation specifications: Provision of the accounting.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.528(c)(1)",
                   "label": "The covered entity must act on the individual's request for an accounting, no later than 60 days after receipt of such a request, as follows.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.528(c)(1)(i)",
@@ -4381,11 +4658,12 @@
                     },
                     {
                       "ref": "164.528(c)(1)(ii)",
-                      "label": "If the covered entity is unable to provide the accounting within the time required by [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(c)(1)) of this section, the covered entity may extend the time to provide the accounting by no more than 30 days, provided that:",
+                      "label": "If the covered entity is unable to provide the accounting within the time required by paragraph (c)(1) of this section, the covered entity may extend the time to provide the accounting by no more than 30 days, provided that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.528(c)(1)(ii)(A)",
-                          "label": "The covered entity, within the time limit set by [paragraph (c)(1)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(c)(1)) of this section, provides the individual with a written statement of the reasons for the delay and the date by which the covered entity will provide the accounting; and"
+                          "label": "The covered entity, within the time limit set by paragraph (c)(1) of this section, provides the individual with a written statement of the reasons for the delay and the date by which the covered entity will provide the accounting; and"
                         },
                         {
                           "ref": "164.528(c)(1)(ii)(B)",
@@ -4404,11 +4682,12 @@
             {
               "ref": "164.528(d)",
               "label": "Implementation specification: Documentation.",
-              "description": "A covered entity must document the following and retain the documentation as required by [§ 164.530(j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)):",
+              "description": "A covered entity must document the following and retain the documentation as required by § 164.530(j):",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.528(d)(1)",
-                  "label": "The information required to be included in an accounting under [paragraph (b)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(b)) of this section for disclosures of protected health information that are subject to an accounting under [paragraph (a)](https://www.ecfr.gov/current/title-45/section-164.528#p-164.528(a)) of this section;"
+                  "label": "The information required to be included in an accounting under paragraph (b) of this section for disclosures of protected health information that are subject to an accounting under paragraph (a) of this section;"
                 },
                 {
                   "ref": "164.528(d)(2)",
@@ -4425,13 +4704,16 @@
         {
           "ref": "164.530",
           "label": "Administrative requirements.",
+          "group": true,
           "controls": [
             {
               "ref": "164.530(a)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.530(a)(1)",
-                  "label": "**Standard: Personnel designations.**",
+                  "label": "Standard: Personnel designations.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.530(a)(1)(i)",
@@ -4439,32 +4721,35 @@
                     },
                     {
                       "ref": "164.530(a)(1)(ii)",
-                      "label": "A covered entity must designate a contact person or office who is responsible for receiving complaints under this section and who is able to provide further information about matters covered by the notice required by [§ 164.520](https://www.ecfr.gov/current/title-45/section-164.520)."
+                      "label": "A covered entity must designate a contact person or office who is responsible for receiving complaints under this section and who is able to provide further information about matters covered by the notice required by § 164.520."
                     }
                   ]
                 },
                 {
                   "ref": "164.530(a)(2)",
                   "label": "Implementation specification: Personnel designations.",
-                  "description": "A covered entity must document the personnel designations in [paragraph (a)(1)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(a)(1)) of this section as required by [paragraph (j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)) of this section."
+                  "description": "A covered entity must document the personnel designations in paragraph (a)(1) of this section as required by paragraph (j) of this section."
                 }
               ]
             },
             {
               "ref": "164.530(b)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.530(b)(1)",
-                  "label": "**Standard: Training.**",
-                  "description": "A covered entity must train all members of its workforce on the policies and procedures with respect to protected health information required by this subpart and [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D), as necessary and appropriate for the members of the workforce to carry out their functions within the covered entity."
+                  "label": "Standard: Training.",
+                  "description": "A covered entity must train all members of its workforce on the policies and procedures with respect to protected health information required by this subpart and subpart D of this part, as necessary and appropriate for the members of the workforce to carry out their functions within the covered entity."
                 },
                 {
                   "ref": "164.530(b)(2)",
                   "label": "Implementation specifications: Training.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.530(b)(2)(i)",
-                      "label": "A covered entity must provide training that meets the requirements of [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(b)(1)) of this section, as follows:",
+                      "label": "A covered entity must provide training that meets the requirements of paragraph (b)(1) of this section, as follows:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.530(b)(2)(i)(A)",
@@ -4476,13 +4761,13 @@
                         },
                         {
                           "ref": "164.530(b)(2)(i)(C)",
-                          "label": "To each member of the covered entity's workforce whose functions are affected by a material change in the policies or procedures required by this subpart or [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D), within a reasonable period of time after the material change becomes effective in accordance with [paragraph (i)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(i)) of this section."
+                          "label": "To each member of the covered entity's workforce whose functions are affected by a material change in the policies or procedures required by this subpart or subpart D of this part, within a reasonable period of time after the material change becomes effective in accordance with paragraph (i) of this section."
                         }
                       ]
                     },
                     {
                       "ref": "164.530(b)(2)(ii)",
-                      "label": "A covered entity must document that the training as described in [paragraph (b)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(b)(2)(i)) of this section has been provided, as required by [paragraph (j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)) of this section."
+                      "label": "A covered entity must document that the training as described in paragraph (b)(2)(i) of this section has been provided, as required by paragraph (j) of this section."
                     }
                   ]
                 }
@@ -4490,6 +4775,7 @@
             },
             {
               "ref": "164.530(c)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.530(c)(1)",
@@ -4498,6 +4784,7 @@
                 },
                 {
                   "ref": "164.530(c)(2)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.530(c)(2)(i)",
@@ -4514,97 +4801,104 @@
             },
             {
               "ref": "164.530(d)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.530(d)(1)",
                   "label": "Standard: Complaints to the covered entity.",
-                  "description": "A covered entity must provide a process for individuals to make complaints concerning the covered entity's policies and procedures required by this subpart and [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D) or its compliance with such policies and procedures or the requirements of this subpart or [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D)."
+                  "description": "A covered entity must provide a process for individuals to make complaints concerning the covered entity's policies and procedures required by this subpart and subpart D of this part or its compliance with such policies and procedures or the requirements of this subpart or subpart D of this part."
                 },
                 {
                   "ref": "164.530(d)(2)",
                   "label": "Implementation specification: Documentation of complaints",
-                  "description": "As required by [paragraph (j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)) of this section, a covered entity must document all complaints received, and their disposition, if any."
+                  "description": "As required by paragraph (j) of this section, a covered entity must document all complaints received, and their disposition, if any."
                 }
               ]
             },
             {
               "ref": "164.530(e)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.530(e)(1)",
-                  "label": "**Standard: Sanctions.**",
-                  "description": "A covered entity must have and apply appropriate sanctions against members of its workforce who fail to comply with the privacy policies and procedures of the covered entity or the requirements of this subpart or [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D). This standard does not apply to a member of the covered entity's workforce with respect to actions that are covered by and that meet the conditions of [§ 164.502(j)](https://www.ecfr.gov/current/title-45/section-164.502#p-164.502(j)) or [paragraph (g)(2)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(g)(2)) of this section."
+                  "label": "Standard: Sanctions.",
+                  "description": "A covered entity must have and apply appropriate sanctions against members of its workforce who fail to comply with the privacy policies and procedures of the covered entity or the requirements of this subpart or subpart D of this part. This standard does not apply to a member of the covered entity's workforce with respect to actions that are covered by and that meet the conditions of § 164.502(j) or paragraph (g)(2) of this section."
                 },
                 {
                   "ref": "164.530(e)(2)",
                   "label": "Implementation specification: Documentation.",
-                  "description": "As required by [paragraph (j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)) of this section, a covered entity must document the sanctions that are applied, if any."
+                  "description": "As required by paragraph (j) of this section, a covered entity must document the sanctions that are applied, if any."
                 }
               ]
             },
             {
               "ref": "164.530(f)",
-              "label": "**Standard: Mitigation.**",
+              "label": "Standard: Mitigation.",
               "description": "A covered entity must mitigate, to the extent practicable, any harmful effect that is known to the covered entity of a use or disclosure of protected health information in violation of its policies and procedures or the requirements of this subpart by the covered entity or its business associate."
             },
             {
               "ref": "164.530(g)",
               "label": "Standard: Refraining from intimidating or retaliatory acts.",
               "description": "A covered entity—",
+              "group": false,
               "controls": [
                 {
                   "ref": "164.530(g)(1)",
-                  "label": "May not intimidate, threaten, coerce, discriminate against, or take other retaliatory action against any individual for the exercise by the individual of any right established, or for participation in any process provided for, by this subpart or [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D), including the filing of a complaint under this section; and"
+                  "label": "May not intimidate, threaten, coerce, discriminate against, or take other retaliatory action against any individual for the exercise by the individual of any right established, or for participation in any process provided for, by this subpart or subpart D of this part, including the filing of a complaint under this section; and"
                 },
                 {
                   "ref": "164.530(g)(2)",
-                  "label": "Must refrain from intimidation and retaliation as provided in [§ 160.316 of this subchapter](https://www.ecfr.gov/current/title-45/section-160.316)."
+                  "label": "Must refrain from intimidation and retaliation as provided in § 160.316 of this subchapter."
                 }
               ]
             },
             {
               "ref": "164.530(h)",
               "label": "Standard: Waiver of rights",
-              "description": "A covered entity may not require individuals to waive their rights under [§ 160.306 of this subchapter](https://www.ecfr.gov/current/title-45/section-160.306), this subpart, or [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D), as a condition of the provision of treatment, payment, enrollment in a health plan, or eligibility for benefits."
+              "description": "A covered entity may not require individuals to waive their rights under § 160.306 of this subchapter, this subpart, or subpart D of this part, as a condition of the provision of treatment, payment, enrollment in a health plan, or eligibility for benefits."
             },
             {
               "ref": "164.530(i)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.530(i)(1)",
-                  "label": "**Standard: Policies and procedures**",
-                  "description": "A covered entity must implement policies and procedures with respect to protected health information that are designed to comply with the standards, implementation specifications, or other requirements of this subpart and [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D). The policies and procedures must be reasonably designed, taking into account the size and the type of activities that relate to protected health information undertaken by a covered entity, to ensure such compliance. This standard is not to be construed to permit or excuse an action that violates any other standard, implementation specification, or other requirement of this subpart."
+                  "label": "Standard: Policies and procedures",
+                  "description": "A covered entity must implement policies and procedures with respect to protected health information that are designed to comply with the standards, implementation specifications, or other requirements of this subpart and subpart D of this part. The policies and procedures must be reasonably designed, taking into account the size and the type of activities that relate to protected health information undertaken by a covered entity, to ensure such compliance. This standard is not to be construed to permit or excuse an action that violates any other standard, implementation specification, or other requirement of this subpart."
                 },
                 {
                   "ref": "164.530(i)(2)",
                   "label": "Standard: Changes to policies and procedures.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.530(i)(2)(i)",
-                      "label": "A covered entity must change its policies and procedures as necessary and appropriate to comply with changes in the law, including the standards, requirements, and implementation specifications of this subpart or [subpart D of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-D)."
+                      "label": "A covered entity must change its policies and procedures as necessary and appropriate to comply with changes in the law, including the standards, requirements, and implementation specifications of this subpart or subpart D of this part."
                     },
                     {
                       "ref": "164.530(i)(2)(ii)",
-                      "label": "When a covered entity changes a privacy practice that is stated in the notice described in [§ 164.520](https://www.ecfr.gov/current/title-45/section-164.520), and makes corresponding changes to its policies and procedures, it may make the changes effective for protected health information that it created or received prior to the effective date of the notice revision, if the covered entity has, in accordance with [§ 164.520(b)(1)(v)(C)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(v)(C)), included in the notice a statement reserving its right to make such a change in its privacy practices; or"
+                      "label": "When a covered entity changes a privacy practice that is stated in the notice described in § 164.520, and makes corresponding changes to its policies and procedures, it may make the changes effective for protected health information that it created or received prior to the effective date of the notice revision, if the covered entity has, in accordance with § 164.520(b)(1)(v)(C), included in the notice a statement reserving its right to make such a change in its privacy practices; or"
                     },
                     {
                       "ref": "164.530(i)(2)(iii)",
-                      "label": "A covered entity may make any other changes to policies and procedures at any time, provided that the changes are documented and implemented in accordance with [paragraph (i)(5)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(i)(5)) of this section."
+                      "label": "A covered entity may make any other changes to policies and procedures at any time, provided that the changes are documented and implemented in accordance with paragraph (i)(5) of this section."
                     }
                   ]
                 },
                 {
                   "ref": "164.530(i)(3)",
                   "label": "Implementation specification: Changes in law.",
-                  "description": "Whenever there is a change in law that necessitates a change to the covered entity's policies or procedures, the covered entity must promptly document and implement the revised policy or procedure. If the change in law materially affects the content of the notice required by [§ 164.520](https://www.ecfr.gov/current/title-45/section-164.520), the covered entity must promptly make the appropriate revisions to the notice in accordance with [§ 164.520(b)(3)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(3)). Nothing in this paragraph may be used by a covered entity to excuse a failure to comply with the law."
+                  "description": "Whenever there is a change in law that necessitates a change to the covered entity's policies or procedures, the covered entity must promptly document and implement the revised policy or procedure. If the change in law materially affects the content of the notice required by § 164.520, the covered entity must promptly make the appropriate revisions to the notice in accordance with § 164.520(b)(3). Nothing in this paragraph may be used by a covered entity to excuse a failure to comply with the law."
                 },
                 {
                   "ref": "164.530(i)(4)",
                   "label": "Implementation specifications: Changes to privacy practices stated in the notice.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.530(i)(4)(i)",
-                      "label": "To implement a change as provided by [paragraph (i)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(i)(2)(ii)) of this section, a covered entity must:",
+                      "label": "To implement a change as provided by paragraph (i)(2)(ii) of this section, a covered entity must:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.530(i)(4)(i)(A)",
@@ -4612,17 +4906,18 @@
                         },
                         {
                           "ref": "164.530(i)(4)(i)(B)",
-                          "label": "Document the policy or procedure, as revised, as required by [paragraph (j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)) of this section; and"
+                          "label": "Document the policy or procedure, as revised, as required by paragraph (j) of this section; and"
                         },
                         {
                           "ref": "164.530(i)(4)(i)(C)",
-                          "label": "Revise the notice as required by [§ 164.520(b)(3)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(3)) to state the changed practice and make the revised notice available as required by [§ 164.520(c)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(c)). The covered entity may not implement a change to a policy or procedure prior to the effective date of the revised notice."
+                          "label": "Revise the notice as required by § 164.520(b)(3) to state the changed practice and make the revised notice available as required by § 164.520(c). The covered entity may not implement a change to a policy or procedure prior to the effective date of the revised notice."
                         }
                       ]
                     },
                     {
                       "ref": "164.530(i)(4)(ii)",
-                      "label": "If a covered entity has not reserved its right under [§ 164.520(b)(1)(v)(C)](https://www.ecfr.gov/current/title-45/section-164.520#p-164.520(b)(1)(v)(C)) to change a privacy practice that is stated in the notice, the covered entity is bound by the privacy practices as stated in the notice with respect to protected health information created or received while such notice is in effect. A covered entity may change a privacy practice that is stated in the notice, and the related policies and procedures, without having reserved the right to do so, provided that:",
+                      "label": "If a covered entity has not reserved its right under § 164.520(b)(1)(v)(C) to change a privacy practice that is stated in the notice, the covered entity is bound by the privacy practices as stated in the notice with respect to protected health information created or received while such notice is in effect. A covered entity may change a privacy practice that is stated in the notice, and the related policies and procedures, without having reserved the right to do so, provided that:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.530(i)(4)(ii)(A)",
@@ -4639,7 +4934,8 @@
                 {
                   "ref": "164.530(i)(5)",
                   "label": "Implementation specification: Changes to other policies or procedures",
-                  "description": "A covered entity may change, at any time, a policy or procedure that does not materially affect the content of the notice required by [§ 164.520](https://www.ecfr.gov/current/title-45/section-164.520), provided that:",
+                  "description": "A covered entity may change, at any time, a policy or procedure that does not materially affect the content of the notice required by § 164.520, provided that:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.530(i)(5)(i)",
@@ -4647,7 +4943,7 @@
                     },
                     {
                       "ref": "164.530(i)(5)(ii)",
-                      "label": "Prior to the effective date of the change, the policy or procedure, as revised, is documented as required by [paragraph (j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)) of this section."
+                      "label": "Prior to the effective date of the change, the policy or procedure, as revised, is documented as required by paragraph (j) of this section."
                     }
                   ]
                 }
@@ -4655,15 +4951,17 @@
             },
             {
               "ref": "164.530(j)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.530(j)(1)",
                   "label": "Standard: Documentation",
                   "description": "A covered entity must:",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.530(j)(1)(i)",
-                      "label": "Maintain the policies and procedures provided for in [paragraph (i)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(i)) of this section in written or electronic form;"
+                      "label": "Maintain the policies and procedures provided for in paragraph (i) of this section in written or electronic form;"
                     },
                     {
                       "ref": "164.530(j)(1)(ii)",
@@ -4675,24 +4973,26 @@
                     },
                     {
                       "ref": "164.530(j)(1)(iv)",
-                      "label": "Maintain documentation sufficient to meet its burden of proof under [§ 164.414(b)](https://www.ecfr.gov/current/title-45/section-164.414#p-164.414(b))."
+                      "label": "Maintain documentation sufficient to meet its burden of proof under § 164.414(b)."
                     }
                   ]
                 },
                 {
                   "ref": "164.530(j)(2)",
                   "label": "Implementation specification: Retention period.",
-                  "description": "A covered entity must retain the documentation required by [paragraph (j)(1)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)(1)) of this section for six years from the date of its creation or the date when it last was in effect, whichever is later."
+                  "description": "A covered entity must retain the documentation required by paragraph (j)(1) of this section for six years from the date of its creation or the date when it last was in effect, whichever is later."
                 }
               ]
             },
             {
               "ref": "164.530(k)",
               "label": "Standard: Group health plans.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.530(k)(1)",
-                  "label": "A group health plan is not subject to the standards or implementation specifications in [paragraphs (a)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(a)) through [(f)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(f)) and [(i)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(i)) of this section, to the extent that:",
+                  "label": "A group health plan is not subject to the standards or implementation specifications in paragraphs (a) through (f) and (i) of this section, to the extent that:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.530(k)(1)(i)",
@@ -4701,10 +5001,11 @@
                     {
                       "ref": "164.530(k)(1)(ii)",
                       "label": "The group health plan does not create or receive protected health information, except for:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.530(k)(1)(ii)(A)",
-                          "label": "Summary health information as defined in [§ 164.504(a)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(a)); or"
+                          "label": "Summary health information as defined in § 164.504(a); or"
                         },
                         {
                           "ref": "164.530(k)(1)(ii)(B)",
@@ -4716,7 +5017,7 @@
                 },
                 {
                   "ref": "164.530(k)(2)",
-                  "label": "A group health plan described in [paragraph (k)(1)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(k)(1)) of this section is subject to the standard and implementation specification in [paragraph (j)](https://www.ecfr.gov/current/title-45/section-164.530#p-164.530(j)) of this section only with respect to plan documents amended in accordance with [§ 164.504(f)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f))."
+                  "label": "A group health plan described in paragraph (k)(1) of this section is subject to the standard and implementation specification in paragraph (j) of this section only with respect to plan documents amended in accordance with § 164.504(f)."
                 }
               ]
             }
@@ -4726,14 +5027,17 @@
     },
     {
       "ref": "Security Rule",
+      "group": true,
       "controls": [
         {
           "ref": "164.306",
           "label": "Security standards: General rules",
+          "group": true,
           "controls": [
             {
               "ref": "164.306(a)",
               "label": "Covered entities and business associates must do the following:",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.306(a)(1)",
@@ -4756,6 +5060,7 @@
             {
               "ref": "164.306(b)",
               "label": "Flexibility of approach.",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.306(b)(1)",
@@ -4764,6 +5069,7 @@
                 {
                   "ref": "164.306(b)(2)",
                   "label": "In deciding which security measures to use, a covered entity or business associate must take into account the following factors:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.306(b)(2)(i)",
@@ -4787,11 +5093,12 @@
             },
             {
               "ref": "164.306(c)",
-              "label": "***Standards.*** A covered entity or business associate must comply with the applicable standards as provided in this section and in [164.308](https://www.ecfr.gov/current/title-45/section-164.308), [164.310](https://www.ecfr.gov/current/title-45/section-164.310), [164.312](https://www.ecfr.gov/current/title-45/section-164.312), [164.314](https://www.ecfr.gov/current/title-45/section-164.314) and [164.316](https://www.ecfr.gov/current/title-45/section-164.316) with respect to all electronic protected health information."
+              "label": "Standards. A covered entity or business associate must comply with the applicable standards as provided in this section and in 164.308, 164.310, 164.312, 164.314 and 164.316 with respect to all electronic protected health information."
             },
             {
               "ref": "164.306(d)",
-              "label": "***Implementation specifications.*** In this subpart:",
+              "label": "Implementation specifications. In this subpart:",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.306(d)(1)",
@@ -4799,11 +5106,12 @@
                 },
                 {
                   "ref": "164.306(d)(2)",
-                  "label": "When a standard adopted in [§ 164.308](https://www.ecfr.gov/current/title-45/section-164.308), [§ 164.310](https://www.ecfr.gov/current/title-45/section-164.310), [§ 164.312](https://www.ecfr.gov/current/title-45/section-164.312), [§ 164.314](https://www.ecfr.gov/current/title-45/section-164.314), or [§ 164.316](https://www.ecfr.gov/current/title-45/section-164.316) includes required implementation specifications, a covered entity or business associate must implement the implementation specifications."
+                  "label": "When a standard adopted in § 164.308, § 164.310, § 164.312, § 164.314, or § 164.316 includes required implementation specifications, a covered entity or business associate must implement the implementation specifications."
                 },
                 {
                   "ref": "164.306(d)(3)",
-                  "label": "When a standard adopted in [§ 164.308](https://www.ecfr.gov/current/title-45/section-164.308), [§ 164.310](https://www.ecfr.gov/current/title-45/section-164.310), [§ 164.312](https://www.ecfr.gov/current/title-45/section-164.312), [§ 164.314](https://www.ecfr.gov/current/title-45/section-164.314), or [§ 164.316](https://www.ecfr.gov/current/title-45/section-164.316) includes addressable implementation specifications, a covered entity or business associate must—",
+                  "label": "When a standard adopted in § 164.308, § 164.310, § 164.312, § 164.314, or § 164.316 includes addressable implementation specifications, a covered entity or business associate must—",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.306(d)(3)(i)",
@@ -4812,6 +5120,7 @@
                     {
                       "ref": "164.306(d)(3)(ii)",
                       "label": "As applicable to the covered entity or business associate—",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.306(d)(3)(ii)(A)",
@@ -4820,7 +5129,7 @@
                         {
                           "ref": "164.306(d)(3)(ii)(B)",
                           "label": "Implement the implementation specification if reasonable and appropriate; or",
-                          "description": "If implementing the implementation specification is not reasonable and appropriate—\n\n$(*1*) Document why it would not be reasonable and appropriate to implement the implementation specification; and\n\n$(*2*) Implement an equivalent alternative measure if reasonable and appropriate."
+                          "description": "If implementing the implementation specification is not reasonable and appropriate—\n\n(1) Document why it would not be reasonable and appropriate to implement the implementation specification; and\n\n(2) Implement an equivalent alternative measure if reasonable and appropriate."
                         }
                       ]
                     }
@@ -4830,21 +5139,24 @@
             },
             {
               "ref": "164.306(e)",
-              "label": "***Maintenance.***",
-              "description": "A covered entity or business associate must review and modify the security measures implemented under this subpart as needed to continue provision of reasonable and appropriate protection of electronic protected health information, and update documentation of such security measures in accordance with [§ 164.316(b)(2)(iii)](https://www.ecfr.gov/current/title-45/section-164.316#p-164.316(b)(2)(iii))."
+              "label": "Maintenance.",
+              "description": "A covered entity or business associate must review and modify the security measures implemented under this subpart as needed to continue provision of reasonable and appropriate protection of electronic protected health information, and update documentation of such security measures in accordance with § 164.316(b)(2)(iii)."
             }
           ]
         },
         {
           "ref": "164.308",
           "label": "Administrative safeguards.",
+          "group": true,
           "controls": [
             {
               "ref": "164.308(a)",
-              "label": "A covered entity or business associate must, in accordance with [§ 164.306](https://www.ecfr.gov/current/title-45/section-164.306):",
+              "label": "A covered entity or business associate must, in accordance with § 164.306:",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.308(a)(1)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.308(a)(1)(i)",
@@ -4854,22 +5166,23 @@
                     {
                       "ref": "164.308(a)(1)(ii)",
                       "label": "Implementation specifications:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.308(a)(1)(ii)(A)",
-                          "label": "***Risk analysis (Required).*** Conduct an accurate and thorough assessment of the potential risks and vulnerabilities to the confidentiality, integrity, and availability of electronic protected health information held by the covered entity or business associate."
+                          "label": "Risk analysis (Required). Conduct an accurate and thorough assessment of the potential risks and vulnerabilities to the confidentiality, integrity, and availability of electronic protected health information held by the covered entity or business associate."
                         },
                         {
                           "ref": "164.308(a)(1)(ii)(B)",
-                          "label": "***Risk management (Required).*** Implement security measures sufficient to reduce risks and vulnerabilities to a reasonable and appropriate level to comply with [§ 164.306(a)](https://www.ecfr.gov/current/title-45/section-164.306#p-164.306(a))."
+                          "label": "Risk management (Required). Implement security measures sufficient to reduce risks and vulnerabilities to a reasonable and appropriate level to comply with § 164.306(a)."
                         },
                         {
                           "ref": "164.308(a)(1)(ii)(C)",
-                          "label": "***Sanction policy (Required).*** Apply appropriate sanctions against workforce members who fail to comply with the security policies and procedures of the covered entity or business associate."
+                          "label": "Sanction policy (Required). Apply appropriate sanctions against workforce members who fail to comply with the security policies and procedures of the covered entity or business associate."
                         },
                         {
                           "ref": "164.308(a)(1)(ii)(D)",
-                          "label": "***Information system activity review (Required).*** Implement procedures to regularly review records of information system activity, such as audit logs, access reports, and security incident tracking reports."
+                          "label": "Information system activity review (Required). Implement procedures to regularly review records of information system activity, such as audit logs, access reports, and security incident tracking reports."
                         }
                       ]
                     }
@@ -4882,15 +5195,17 @@
                 },
                 {
                   "ref": "164.308(a)(3)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.308(a)(3)(i)",
-                      "label": "***Standard: Workforce security***",
-                      "description": "Implement policies and procedures to ensure that all members of its workforce have appropriate access to electronic protected health information, as provided under [paragraph (a)(4)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(a)(4)) of this section, and to prevent those workforce members who do not have access under [paragraph (a)(4)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(a)(4)) of this section from obtaining access to electronic protected health information."
+                      "label": "Standard: Workforce security",
+                      "description": "Implement policies and procedures to ensure that all members of its workforce have appropriate access to electronic protected health information, as provided under paragraph (a)(4) of this section, and to prevent those workforce members who do not have access under paragraph (a)(4) of this section from obtaining access to electronic protected health information."
                     },
                     {
                       "ref": "164.308(a)(3)(ii)",
                       "label": "Implementation specifications:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.308(a)(3)(ii)(A)",
@@ -4905,7 +5220,7 @@
                         {
                           "ref": "164.308(a)(3)(ii)(C)",
                           "label": "Termination procedures (Addressable)",
-                          "description": "Implement procedures for terminating access to electronic protected health information when the employment of, or other arrangement with, a workforce member ends or as required by determinations made as specified in [paragraph (a)(3)(ii)(B)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(a)(3)(ii)(B)) of this section."
+                          "description": "Implement procedures for terminating access to electronic protected health information when the employment of, or other arrangement with, a workforce member ends or as required by determinations made as specified in paragraph (a)(3)(ii)(B) of this section."
                         }
                       ]
                     }
@@ -4913,15 +5228,17 @@
                 },
                 {
                   "ref": "164.308(a)(4)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.308(a)(4)(i)",
                       "label": "Standard: Information access management",
-                      "description": "Implement policies and procedures for authorizing access to electronic protected health information that are consistent with the applicable requirements of [subpart E of this part](https://www.ecfr.gov/current/title-45/part-164/subpart-E)."
+                      "description": "Implement policies and procedures for authorizing access to electronic protected health information that are consistent with the applicable requirements of subpart E of this part."
                     },
                     {
                       "ref": "164.308(a)(4)(ii)",
                       "label": "Implementation specifications:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.308(a)(4)(ii)(A)",
@@ -4944,6 +5261,7 @@
                 },
                 {
                   "ref": "164.308(a)(5)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.308(a)(5)(i)",
@@ -4952,8 +5270,9 @@
                     },
                     {
                       "ref": "164.308(a)(5)(ii)",
-                      "label": "***Implementation specifications.***",
+                      "label": "Implementation specifications.",
                       "description": "Implement:",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.308(a)(5)(ii)(A)",
@@ -4981,6 +5300,7 @@
                 },
                 {
                   "ref": "164.308(a)(6)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.308(a)(6)(i)",
@@ -4996,15 +5316,17 @@
                 },
                 {
                   "ref": "164.308(a)(7)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.308(a)(7)(i)",
-                      "label": "***Standard: Contingency plan.***",
+                      "label": "Standard: Contingency plan.",
                       "description": "Establish (and implement as needed) policies and procedures for responding to an emergency or other occurrence (for example, fire, vandalism, system failure, and natural disaster) that damages systems that contain electronic protected health information."
                     },
                     {
                       "ref": "164.308(a)(7)(ii)",
                       "label": "Implementation specifications:",
+                      "group": true,
                       "controls": [
                         {
                           "ref": "164.308(a)(7)(ii)(A)",
@@ -5013,7 +5335,7 @@
                         },
                         {
                           "ref": "164.308(a)(7)(ii)(B)",
-                          "label": "**Disaster recovery plan (Required).**",
+                          "label": "Disaster recovery plan (Required).",
                           "description": "Establish (and implement as needed) procedures to restore any loss of data."
                         },
                         {
@@ -5044,20 +5366,21 @@
             },
             {
               "ref": "164.308(b)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.308(b)(1)",
                   "label": "Business associate contracts and other arrangements",
-                  "description": "A covered entity may permit a business associate to create, receive, maintain, or transmit electronic protected health information on the covered entity's behalf only if the covered entity obtains satisfactory assurances, in accordance with [§ 164.314(a)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)), that the business associate will appropriately safeguard the information. A covered entity is not required to obtain such satisfactory assurances from a business associate that is a subcontractor."
+                  "description": "A covered entity may permit a business associate to create, receive, maintain, or transmit electronic protected health information on the covered entity's behalf only if the covered entity obtains satisfactory assurances, in accordance with § 164.314(a), that the business associate will appropriately safeguard the information. A covered entity is not required to obtain such satisfactory assurances from a business associate that is a subcontractor."
                 },
                 {
                   "ref": "164.308(b)(2)",
-                  "label": "A business associate may permit a business associate that is a subcontractor to create, receive, maintain, or transmit electronic protected health information on its behalf only if the business associate obtains satisfactory assurances, in accordance with [§ 164.314(a)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)), that the subcontractor will appropriately safeguard the information."
+                  "label": "A business associate may permit a business associate that is a subcontractor to create, receive, maintain, or transmit electronic protected health information on its behalf only if the business associate obtains satisfactory assurances, in accordance with § 164.314(a), that the subcontractor will appropriately safeguard the information."
                 },
                 {
                   "ref": "164.308(b)(3)",
                   "label": "Implementation specifications: Written contract or other arrangement (Required)",
-                  "description": "Document the satisfactory assurances required by [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(b)(1)) or [(b)(2)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(b)(2)) of this section through a written contract or other arrangement with the business associate that meets the applicable requirements of [§ 164.314(a)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a))."
+                  "description": "Document the satisfactory assurances required by paragraph (b)(1) or (b)(2) of this section through a written contract or other arrangement with the business associate that meets the applicable requirements of § 164.314(a)."
                 }
               ]
             }
@@ -5066,10 +5389,12 @@
         {
           "ref": "164.310",
           "label": "Physical safeguards.",
-          "description": "A covered entity or business associate must, in accordance with [§ 164.306](https://www.ecfr.gov/current/title-45/section-164.306):",
+          "description": "A covered entity or business associate must, in accordance with § 164.306:",
+          "group": false,
           "controls": [
             {
               "ref": "164.310(a)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.310(a)(1)",
@@ -5079,6 +5404,7 @@
                 {
                   "ref": "164.310(a)(2)",
                   "label": "Implementation specifications:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.310(a)(2)(i)",
@@ -5116,6 +5442,7 @@
             },
             {
               "ref": "164.310(d)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.310(d)(1)",
@@ -5124,7 +5451,8 @@
                 },
                 {
                   "ref": "164.310(d)(2)",
-                  "label": "**Implementation specifications:**",
+                  "label": "Implementation specifications:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.310(d)(2)(i)",
@@ -5155,19 +5483,22 @@
         {
           "ref": "164.312",
           "label": "Technical safeguards.",
-          "description": "A covered entity or business associate must, in accordance with [§ 164.306](https://www.ecfr.gov/current/title-45/section-164.306):",
+          "description": "A covered entity or business associate must, in accordance with § 164.306:",
+          "group": false,
           "controls": [
             {
               "ref": "164.312(a)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.312(a)(1)",
-                  "label": "**Standard: Access control.**",
-                  "description": "Implement technical policies and procedures for electronic information systems that maintain electronic protected health information to allow access only to those persons or software programs that have been granted access rights as specified in [§ 164.308(a)(4)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(a)(4))."
+                  "label": "Standard: Access control.",
+                  "description": "Implement technical policies and procedures for electronic information systems that maintain electronic protected health information to allow access only to those persons or software programs that have been granted access rights as specified in § 164.308(a)(4)."
                 },
                 {
                   "ref": "164.312(a)(2)",
                   "label": "Implementation specifications:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.312(a)(2)(i)",
@@ -5200,6 +5531,7 @@
             },
             {
               "ref": "164.312(c)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.312(c)(1)",
@@ -5215,11 +5547,12 @@
             },
             {
               "ref": "164.312(d)",
-              "label": "**Standard: Person or entity authentication.**",
+              "label": "Standard: Person or entity authentication.",
               "description": "Implement procedures to verify that a person or entity seeking access to electronic protected health information is the one claimed."
             },
             {
               "ref": "164.312(e)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.312(e)(1)",
@@ -5229,6 +5562,7 @@
                 {
                   "ref": "164.312(e)(2)",
                   "label": "Implementation specifications:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.312(e)(2)(i)",
@@ -5249,23 +5583,27 @@
         {
           "ref": "164.314",
           "label": "Organizational requirements.",
+          "group": true,
           "controls": [
             {
               "ref": "164.314(a)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.314(a)(1)",
                   "label": "Standard: Business associate contracts or other arrangements.",
-                  "description": "The contract or other arrangement required by [§ 164.308(b)(3)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(b)(3)) must meet the requirements of [paragraph (a)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(2)(i)), [(a)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(2)(ii)), or [(a)(2)(iii)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(2)(iii)) of this section, as applicable."
+                  "description": "The contract or other arrangement required by § 164.308(b)(3) must meet the requirements of paragraph (a)(2)(i), (a)(2)(ii), or (a)(2)(iii) of this section, as applicable."
                 },
                 {
                   "ref": "164.314(a)(2)",
-                  "label": "**Implementation specifications (Required)**",
+                  "label": "Implementation specifications (Required)",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.314(a)(2)(i)",
                       "label": "Business associate contracts",
                       "description": "The contract must provide that the business associate will—",
+                      "group": false,
                       "controls": [
                         {
                           "ref": "164.314(a)(2)(i)(A)",
@@ -5273,23 +5611,23 @@
                         },
                         {
                           "ref": "164.314(a)(2)(i)(B)",
-                          "label": "In accordance with [§ 164.308(b)(2)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(b)(2)), ensure that any subcontractors that create, receive, maintain, or transmit electronic protected health information on behalf of the business associate agree to comply with the applicable requirements of this subpart by entering into a contract or other arrangement that complies with this section; and"
+                          "label": "In accordance with § 164.308(b)(2), ensure that any subcontractors that create, receive, maintain, or transmit electronic protected health information on behalf of the business associate agree to comply with the applicable requirements of this subpart by entering into a contract or other arrangement that complies with this section; and"
                         },
                         {
                           "ref": "164.314(a)(2)(i)(C)",
-                          "label": "Report to the covered entity any security incident of which it becomes aware, including breaches of unsecured protected health information as required by [§ 164.410](https://www.ecfr.gov/current/title-45/section-164.410)."
+                          "label": "Report to the covered entity any security incident of which it becomes aware, including breaches of unsecured protected health information as required by § 164.410."
                         }
                       ]
                     },
                     {
                       "ref": "164.314(a)(2)(ii)",
                       "label": "Other arrangements",
-                      "description": "The covered entity is in compliance with [paragraph (a)(1)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(1)) of this section if it has another arrangement in place that meets the requirements of [§ 164.504(e)(3)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(e)(3))."
+                      "description": "The covered entity is in compliance with paragraph (a)(1) of this section if it has another arrangement in place that meets the requirements of § 164.504(e)(3)."
                     },
                     {
                       "ref": "164.314(a)(2)(iii)",
                       "label": "Business associate contracts with subcontractors",
-                      "description": "The requirements of [paragraphs (a)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(2)(i)) and [(a)(2)(ii)](https://www.ecfr.gov/current/title-45/section-164.314#p-164.314(a)(2)(ii)) of this section apply to the contract or other arrangement between a business associate and a subcontractor required by [§ 164.308(b)(4)](https://www.ecfr.gov/current/title-45/section-164.308#p-164.308(b)(4)) in the same manner as such requirements apply to contracts or other arrangements between a covered entity and business associate."
+                      "description": "The requirements of paragraphs (a)(2)(i) and (a)(2)(ii) of this section apply to the contract or other arrangement between a business associate and a subcontractor required by § 164.308(b)(4) in the same manner as such requirements apply to contracts or other arrangements between a covered entity and business associate."
                     }
                   ]
                 }
@@ -5297,16 +5635,18 @@
             },
             {
               "ref": "164.314(b)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.314(b)(1)",
                   "label": "Standard: Requirements for group health plans",
-                  "description": "Except when the only electronic protected health information disclosed to a plan sponsor is disclosed pursuant to [§ 164.504(f)(1)(ii)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(1)(ii)) or [(iii)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(1)(iii)), or as authorized under [§ 164.508](https://www.ecfr.gov/current/title-45/section-164.508), a group health plan must ensure that its plan documents provide that the plan sponsor will reasonably and appropriately safeguard electronic protected health information created, received, maintained, or transmitted to or by the plan sponsor on behalf of the group health plan."
+                  "description": "Except when the only electronic protected health information disclosed to a plan sponsor is disclosed pursuant to § 164.504(f)(1)(ii) or (iii), or as authorized under § 164.508, a group health plan must ensure that its plan documents provide that the plan sponsor will reasonably and appropriately safeguard electronic protected health information created, received, maintained, or transmitted to or by the plan sponsor on behalf of the group health plan."
                 },
                 {
                   "ref": "164.314(b)(2)",
                   "label": "Implementation specifications (Required).",
                   "description": "The plan documents of the group health plan must be amended to incorporate provisions to require the plan sponsor to—",
+                  "group": false,
                   "controls": [
                     {
                       "ref": "164.314(b)(2)(i)",
@@ -5314,7 +5654,7 @@
                     },
                     {
                       "ref": "164.314(b)(2)(ii)",
-                      "label": "Ensure that the adequate separation required by [§ 164.504(f)(2)(iii)](https://www.ecfr.gov/current/title-45/section-164.504#p-164.504(f)(2)(iii)) is supported by reasonable and appropriate security measures;"
+                      "label": "Ensure that the adequate separation required by § 164.504(f)(2)(iii) is supported by reasonable and appropriate security measures;"
                     },
                     {
                       "ref": "164.314(b)(2)(iii)",
@@ -5333,19 +5673,22 @@
         {
           "ref": "164.316",
           "label": "Policies and procedures and documentation requirements.",
-          "description": "A covered entity or business associate must, in accordance with [§ 164.306](https://www.ecfr.gov/current/title-45/section-164.306):",
+          "description": "A covered entity or business associate must, in accordance with § 164.306:",
+          "group": false,
           "controls": [
             {
               "ref": "164.316(a)",
               "label": "Standard: Policies and procedures.",
-              "description": "Implement reasonable and appropriate policies and procedures to comply with the standards, implementation specifications, or other requirements of this subpart, taking into account those factors specified in [§ 164.306(b)(2)(i)](https://www.ecfr.gov/current/title-45/section-164.306#p-164.306(b)(2)(i)), [(ii)](https://www.ecfr.gov/current/title-45/section-164.306#p-164.306(b)(2)(ii)), [(iii)](https://www.ecfr.gov/current/title-45/section-164.306#p-164.306(b)(2)(iii)), and [(iv)](https://www.ecfr.gov/current/title-45/section-164.306#p-164.306(b)(2)(iv)). This standard is not to be construed to permit or excuse an action that violates any other standard, implementation specification, or other requirements of this subpart. A covered entity or business associate may change its policies and procedures at any time, provided that the changes are documented and are implemented in accordance with this subpart."
+              "description": "Implement reasonable and appropriate policies and procedures to comply with the standards, implementation specifications, or other requirements of this subpart, taking into account those factors specified in § 164.306(b)(2)(i), (ii), (iii), and (iv). This standard is not to be construed to permit or excuse an action that violates any other standard, implementation specification, or other requirements of this subpart. A covered entity or business associate may change its policies and procedures at any time, provided that the changes are documented and are implemented in accordance with this subpart."
             },
             {
               "ref": "164.316(b)",
+              "group": true,
               "controls": [
                 {
                   "ref": "164.316(b)(1)",
                   "label": "Standard: Documentation.",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.316(b)(1)(i)",
@@ -5360,11 +5703,12 @@
                 {
                   "ref": "164.316(b)(2)",
                   "label": "Implementation specifications:",
+                  "group": true,
                   "controls": [
                     {
                       "ref": "164.316(b)(2)(i)",
                       "label": "Time limit (Required).",
-                      "description": "Retain the documentation required by [paragraph (b)(1)](https://www.ecfr.gov/current/title-45/section-164.316#p-164.316(b)(1)) of this section for 6 years from the date of its creation or the date when it last was in effect, whichever is later"
+                      "description": "Retain the documentation required by paragraph (b)(1) of this section for 6 years from the date of its creation or the date when it last was in effect, whichever is later"
                     },
                     {
                       "ref": "164.316(b)(2)(ii)",


### PR DESCRIPTION
## Summary

The `us-hipaa.json` source carried ecfr.gov scrape artifacts that surfaced on import:

- **Raw bold markers in titles** — e.g. `**Standard: Deceased individuals.**` rendered literally because titles are plain text.
- **Markdown cross-reference links** — `[paragraph (a)](https://www.ecfr.gov/...)` rendered as styled-but-dead blue links.

This cleans the source so it imports cleanly, and assigns explicit group flags.

## Changes

| Fix | Result |
|-----|--------|
| Bold/italic markers (`*`, `**`, `***`) in labels & descriptions | Stripped, text kept verbatim (301 labels, 113 descriptions touched) |
| Markdown links `[text](url)` | Flattened to plain text, ecfr.gov URLs dropped, `§` preserved |
| Mangled split-link artifacts | `[paragraph (a)(5)(ii)(B)(](…)[*2*](…)[)](…)` → `paragraph (a)(5)(ii)(B)(2)`; `$(*1*)` → `(1)` |
| Group flags | Parents that only frame children (no own requirement text) → `group:true` (245); parents that carry their own text → `group:false` so they stay attestable (99); leaves untouched |
| `last_updated` | bumped to `2026-06-26` |

## Validation

- `bun run frameworks:check` (JSON lint + schema) passes.
- Verified end-to-end through eload's loader and against a local catalog reload: 1,114 controls → 245 groups + 869 attestable, **0** residual markdown in titles or descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)