### PR TITLE
feat: add csa cloud controls matrix v4.1 framework

### DIFF
--- a/frameworks/csa-ccm-4-1.json
+++ b/frameworks/csa-ccm-4-1.json
@@ -1,0 +1,1175 @@
+{
+  "key": "csa-ccm-4-1",
+  "name": "CSA Cloud Controls Matrix",
+  "short_name": "CSA CCM",
+  "version": "4.1.0",
+  "publisher": "Cloud Security Alliance",
+  "source_url": "https://cloudsecurityalliance.org/research/cloud-controls-matrix",
+  "scf_keys": [
+    "csa-ccm-4-1-0"
+  ],
+  "last_updated": "2026-06-26",
+  "description": "Cybersecurity control framework for cloud computing, composed of 197 control objectives across 17 domains, covering all key aspects of cloud technology.",
+  "category": "framework",
+  "keywords": [
+    "cloud",
+    "cybersecurity",
+    "framework"
+  ],
+  "controls": [
+    {
+      "ref": "A&A",
+      "label": "Audit & Assurance",
+      "group": true,
+      "controls": [
+        {
+          "ref": "A&A-01",
+          "label": "Audit and Assurance Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain audit and assurance policies and procedures and standards. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "A&A-02",
+          "label": "Independent Assessments",
+          "description": "Conduct independent audit and assurance assessments according to relevant standards at least annually."
+        },
+        {
+          "ref": "A&A-03",
+          "label": "Risk Based Planning Assessment",
+          "description": "Perform independent audit and assurance assessments according to risk-based plans and policies,and in response to significant changes or emerging risks."
+        },
+        {
+          "ref": "A&A-04",
+          "label": "Requirements Compliance",
+          "description": "Verify compliance with all relevant standards, regulations, legal/contractual, and statutory requirements applicable to the audit."
+        },
+        {
+          "ref": "A&A-05",
+          "label": "Audit Management Process",
+          "description": "Define and implement an Audit Management process aligned with relevant auditing standards to support audit planning, risk analysis, security control assessment, conclusion, remediation schedules, report generation, and review of past reports and supporting evidence."
+        },
+        {
+          "ref": "A&A-06",
+          "label": "Remediation",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain a risk-based corrective action plan to remediate audit findings, regularly review and report remediation status to relevant stakeholders."
+        }
+      ]
+    },
+    {
+      "ref": "AIS",
+      "label": "Application & Interface Security",
+      "group": true,
+      "controls": [
+        {
+          "ref": "AIS-01",
+          "label": "Application and Interface Security Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for application security. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "AIS-02",
+          "label": "Application Security Baseline Requirements",
+          "description": "Establish, document and maintain baseline requirements for securing applications."
+        },
+        {
+          "ref": "AIS-03",
+          "label": "Application Security Metrics",
+          "description": "Define and implement technical and operational metrics in alignment with business objectives, security requirements, and compliance obligations."
+        },
+        {
+          "ref": "AIS-04",
+          "label": "Secure Application Development Lifecycle",
+          "description": "Define and implement a secure SDLC process for application requirements analysis, planning, design, development, testing, deployment, and operation in accordance with security requirements."
+        },
+        {
+          "ref": "AIS-05",
+          "label": "Application Security Testing",
+          "description": "Implement a testing strategy, including criteria for acceptance of new information systems, upgrades and new versions, which provides application security assurance and maintains compliance while meeting organizational delivery goals. Automate when applicable and possible."
+        },
+        {
+          "ref": "AIS-06",
+          "label": "Secure Application Deployment",
+          "description": "Establish and implement strategies and capabilities for secure, standardized, and compliant application deployment. Automate where possible."
+        },
+        {
+          "ref": "AIS-07",
+          "label": "Application Vulnerability Remediation",
+          "description": "Define and implement a process to remediate application security vulnerabilities, automating remediation when possible."
+        },
+        {
+          "ref": "AIS-08",
+          "label": "API Security",
+          "description": "Define and implement processes, procedures, and technical measures to secure APIs. Review and update for any improvements at least annually or upon significant changes."
+        }
+      ]
+    },
+    {
+      "ref": "BCR",
+      "label": "Business Continuity Management and Operational Resilience",
+      "group": true,
+      "controls": [
+        {
+          "ref": "BCR-01",
+          "label": "Business Continuity Management Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain business continuity management and operational resilience policies and procedures. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "BCR-02",
+          "label": "Risk Assessment and Impact Analysis",
+          "description": "Determine the impact of business disruptions and risks to establish criteria for developing business continuity and operational resilience strategies and capabilities. Review and update the risk assessment and impact analysis at least annually or upon significant changes."
+        },
+        {
+          "ref": "BCR-03",
+          "label": "Business Continuity Strategy",
+          "description": "Establish strategies to reduce the impact of business disruptions, and improve resiliency and recovery from business disruptions."
+        },
+        {
+          "ref": "BCR-04",
+          "label": "Business Continuity Planning",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain a business continuity plan based on the results of the operational resilience strategies and capabilities."
+        },
+        {
+          "ref": "BCR-05",
+          "label": "Documentation",
+          "description": "Develop, identify, and acquire documentation, both internally and from external parties, that is relevant to support the business continuity and operational resilience plans. Make the documentation available to authorized stakeholders and review at least annually or upon significant changes."
+        },
+        {
+          "ref": "BCR-06",
+          "label": "Business Continuity Exercises",
+          "description": "Exercise and test business continuity and operational resilience plans at least annually or upon significant changes."
+        },
+        {
+          "ref": "BCR-07",
+          "label": "Communication",
+          "description": "Establish and maintain communication channels with all relevant stakeholders in the course of business continuity and resilience procedures."
+        },
+        {
+          "ref": "BCR-08",
+          "label": "Backup",
+          "description": "Periodically perform backups. Ensure the confidentiality, integrity and availability of the backup, and verify restoration from backup for resiliency."
+        },
+        {
+          "ref": "BCR-09",
+          "label": "Disaster Response Plan",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain a disaster response plan to recover from natural and man-made disasters. Update the plan at least annually or upon significant changes."
+        },
+        {
+          "ref": "BCR-10",
+          "label": "Response Plan Exercise",
+          "description": "Exercise the disaster response plan annually or upon significant changes, including if possible, the participation of local emergency authorities."
+        },
+        {
+          "ref": "BCR-11",
+          "label": "Equipment Redundancy",
+          "description": "Supplement business-critical equipment with both locally redundant and geographically dispersed equipment located at a reasonable minimum distance in accordance with applicable industry standards."
+        }
+      ]
+    },
+    {
+      "ref": "CCC",
+      "label": "Change Control and Configuration Management",
+      "group": true,
+      "controls": [
+        {
+          "ref": "CCC-01",
+          "label": "Change Management Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for managing the risks associated with applying changes to assets owned, controlled or used by the organization. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "CCC-02",
+          "label": "Quality Testing",
+          "description": "Establish, maintain and implement a defined quality change control, approval and testing process incorporating baselines, testing, and release standards."
+        },
+        {
+          "ref": "CCC-03",
+          "label": "Change Management Technology",
+          "description": "Implement a change management procedure to manage the risks associated with applying changes to assets, owned, controlled or used by the organization."
+        },
+        {
+          "ref": "CCC-04",
+          "label": "Unauthorized Change Protection",
+          "description": "Implement and enforce a procedure to authorize the addition, removal, update, and management of assets that are owned, controlled or used by the organization."
+        },
+        {
+          "ref": "CCC-05",
+          "label": "Change Agreements",
+          "description": "Include provisions limiting changes directly impacting service customers owned environments (tenants) to explicitly authorized requests within service level agreements."
+        },
+        {
+          "ref": "CCC-06",
+          "label": "Change Management Baseline",
+          "description": "Establish, document and implement change management and configuration baselines for all relevant authorized changes on organization assets. Review and update the baselines at least annually or upon significant changes."
+        },
+        {
+          "ref": "CCC-07",
+          "label": "Detection of Baseline Deviation",
+          "description": "Implement detection measures with proactive notification in case of changes deviating from the established baseline."
+        },
+        {
+          "ref": "CCC-08",
+          "label": "Exception Management",
+          "description": "Implement a procedure for the management of exceptions, including emergencies, in the change and configuration process. Align the procedure with the requirements of GRC-04: Policy Exception Process."
+        },
+        {
+          "ref": "CCC-09",
+          "label": "Change Restoration",
+          "description": "Define and implement a process to proactively roll back changes to a previous known good state in case of errors or security concerns."
+        }
+      ]
+    },
+    {
+      "ref": "CEK",
+      "label": "Cryptography, Encryption & Key Management",
+      "group": true,
+      "controls": [
+        {
+          "ref": "CEK-01",
+          "label": "Encryption and Key Management Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for Cryptography, Encryption and Key Management. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "CEK-02",
+          "label": "CEK Roles and Responsibilities",
+          "description": "Define and implement cryptographic, encryption and key management roles and responsibilities."
+        },
+        {
+          "ref": "CEK-03",
+          "label": "Data Protection",
+          "description": "Provide data protection at-rest, in-transit, and where applicable, in-use by using cryptographic libraries certified to approved standards."
+        },
+        {
+          "ref": "CEK-04",
+          "label": "Encryption Algorithm",
+          "description": "Utilize encryption algorithms following industry standards for protecting data, based on the data classification and associated risks."
+        },
+        {
+          "ref": "CEK-05",
+          "label": "Encryption Change Management",
+          "description": "Establish a standard change management procedure, to accommodate changes from internal and external sources, for review, approval, implementation and communication of cryptographic, encryption and key management technology changes."
+        },
+        {
+          "ref": "CEK-06",
+          "label": "Encryption Change Cost Benefit Analysis",
+          "description": "Manage and adopt changes to cryptography-, encryption-, and key management-related systems (including policies and procedures) that fully account for downstream effects of proposed changes, including residual risk, cost, and benefits analysis."
+        },
+        {
+          "ref": "CEK-07",
+          "label": "Encryption Risk Management",
+          "description": "Establish and maintain an encryption and key management risk program that includes provisions for risk assessment, risk treatment, risk context, monitoring, and feedback."
+        },
+        {
+          "ref": "CEK-08",
+          "label": "Service Customer Key Management Capability",
+          "description": "Service providers must provide the capability for service customers to manage their own data encryption keys."
+        },
+        {
+          "ref": "CEK-09",
+          "label": "Encryption and Key Management Audit",
+          "description": "Audit encryption and key management systems, policies, and processes with a frequency that is proportional to the risk exposure of the system with audit occurring preferably continuously but at least annually and upon any security event(s)."
+        },
+        {
+          "ref": "CEK-10",
+          "label": "Key Generation",
+          "description": "Generate Cryptographic keys using industry accepted cryptographic libraries specifying the algorithm strength and the random number generator used."
+        },
+        {
+          "ref": "CEK-11",
+          "label": "Key Purpose",
+          "description": "Manage cryptographic secret and private keys that are provisioned for a unique purpose."
+        },
+        {
+          "ref": "CEK-12",
+          "label": "Key Rotation",
+          "description": "Rotate cryptographic keys in accordance with the calculated cryptoperiod, which includes provisions for considering the risk of information disclosure and legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-13",
+          "label": "Key Revocation",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to revoke and remove cryptographic keys prior to the end of its established cryptoperiod, when a key is compromised, or an entity is no longer part of the organization, which include provisions for legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-14",
+          "label": "Key Destruction",
+          "description": "Define, implement, and evaluate processes, procedures, and technical measures to securely destroy cryptographic keys when they are no longer needed, which include provisions for legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-15",
+          "label": "Key Activation",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to create keys in a pre-activated state when they have been generated but not authorized for use, which include provisions for legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-16",
+          "label": "Key Suspension",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to monitor, review and approve key transitions from any state to/from suspension, which include provisions for legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-17",
+          "label": "Key Deactivation",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to deactivate keys at the time of their expiration date, which include provisions for legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-18",
+          "label": "Key Archival",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to manage archived keys in a secure repository requiring least privilege access, which include provisions for legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-19",
+          "label": "Key Compromise",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to use compromised keys to encrypt information only in controlled circumstance, and thereafter exclusively for decrypting data and never for encrypting data, which include provisions for legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-20",
+          "label": "Key Recovery",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to assess the risk to operational continuity versus the risk of the keying material and the information it protects being exposed if control of the keying material is lost, which include provisions for legal and regulatory requirements."
+        },
+        {
+          "ref": "CEK-21",
+          "label": "Key Inventory Management",
+          "description": "Define, implement and evaluate processes, procedures and technical measures in order for the key management system to track and report all cryptographic materials and changes in status, which include provisions for legal and regulatory requirements."
+        }
+      ]
+    },
+    {
+      "ref": "DCS",
+      "label": "Datacenter Security",
+      "group": true,
+      "controls": [
+        {
+          "ref": "DCS-01",
+          "label": "Physical and Environmental Security Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for physical and environmental security. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "DCS-02",
+          "label": "Off-Site Equipment Disposal Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for the secure disposal of equipment used outside the organization's premises. If the equipment is not physically destroyed a data destruction procedure that renders recovery of information impossible must be applied. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "DCS-03",
+          "label": "Off-Site Transfer Authorization Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for the relocation or transfer of hardware, software, or data/information to an offsite or alternate location. The relocation or transfer request requires the written or cryptographically verifiable authorization. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "DCS-04",
+          "label": "Secure Area Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for maintaining a safe and secure working environment in offices, rooms, and facilities. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "DCS-05",
+          "label": "Secure Media Transportation Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for the secure transportation of physical media. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "DCS-06",
+          "label": "Assets Classification",
+          "description": "Classify and document the physical, and logical assets (e.g., applications) based on the organizational business risk. Review and update the assets’ classification at least annually, or upon significant changes."
+        },
+        {
+          "ref": "DCS-07",
+          "label": "Assets Cataloguing and Tracking",
+          "description": "Catalogue and track all relevant physical and logical assets located at all of the service provider's sites within a secured system. Review and update the catalogue at least annually or upon significant changes."
+        },
+        {
+          "ref": "DCS-08",
+          "label": "Controlled Physical Access Points",
+          "description": "Design and implement physical security perimeters to safeguard personnel, data, and information systems."
+        },
+        {
+          "ref": "DCS-09",
+          "label": "Equipment Identification",
+          "description": "Use equipment identification as a method for connection authentication."
+        },
+        {
+          "ref": "DCS-10",
+          "label": "Secure Area Authorization",
+          "description": "Allow only authorized personnel access to secure areas, with all ingress and egress points restricted, documented, and monitored by physical access control mechanisms. Retain access control records on a periodic basis as deemed appropriate by the organization."
+        },
+        {
+          "ref": "DCS-11",
+          "label": "Surveillance System",
+          "description": "Implement, maintain, and operate datacenter surveillance systems at the external perimeter and at all the ingress and egress points to detect unauthorized ingress and egress attempts."
+        },
+        {
+          "ref": "DCS-12",
+          "label": "Adverse Event Response Training",
+          "description": "Train datacenter personnel to safely manage adverse events, including but not limited to unauthorized ingress and egress attempts."
+        },
+        {
+          "ref": "DCS-13",
+          "label": "Cabling Security",
+          "description": "Define, implement and evaluate processes, procedures and technical measures that ensure a risk-based protection of power and telecommunication cables from a threat of interception, interference or damage at all facilities, offices and rooms."
+        },
+        {
+          "ref": "DCS-14",
+          "label": "Environmental Systems",
+          "description": "Implement and maintain data center environmental control systems that monitor, maintain and test for continual effectiveness the temperature and humidity conditions within accepted industry standards."
+        },
+        {
+          "ref": "DCS-15",
+          "label": "Secure Utilities",
+          "description": "Secure, monitor, maintain, and test utilities services for continual effectiveness at planned intervals."
+        },
+        {
+          "ref": "DCS-16",
+          "label": "Equipment Location",
+          "description": "Keep business-critical equipment away from locations subject to high probability for environmental risk events."
+        },
+        {
+          "ref": "DCS-17",
+          "label": "Datacenter Metrics",
+          "description": "Establish, monitor and report datacenter security metrics to secure data center assets and services."
+        },
+        {
+          "ref": "DCS-18",
+          "label": "Datacenter Operations Resilience",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to ensure continuous operations."
+        }
+      ]
+    },
+    {
+      "ref": "DSP",
+      "label": "Data Security and Privacy Lifecycle Management",
+      "group": true,
+      "controls": [
+        {
+          "ref": "DSP-01",
+          "label": "Security and Privacy Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for the preparation, classification, protection and handling of data throughout its lifecycle, and according to all applicable laws and regulations, standards, and risk level. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "DSP-02",
+          "label": "Secure Disposal",
+          "description": "Apply industry accepted methods for the secure disposal of data from storage media such that data is not recoverable by any forensic means."
+        },
+        {
+          "ref": "DSP-03",
+          "label": "Data Inventory",
+          "description": "Create and maintain a data inventory, at least for any sensitive, regulated and personal data. Review and update the inventory at least annually or upon significant changes."
+        },
+        {
+          "ref": "DSP-04",
+          "label": "Data Classification",
+          "description": "Classify data according to its type, criticality and sensitivity level."
+        },
+        {
+          "ref": "DSP-05",
+          "label": "Data Flow Documentation",
+          "description": "Create data flow documentation to identify what data is processed, stored or transmitted where. Review data flow documentation at defined intervals, at least annually, or upon significant changes."
+        },
+        {
+          "ref": "DSP-06",
+          "label": "Data Ownership and Stewardship",
+          "description": "Document ownership and stewardship of all relevant documented personal and sensitive data. Perform review at least annually."
+        },
+        {
+          "ref": "DSP-07",
+          "label": "Data Protection by Design and Default",
+          "description": "Develop systems, products, and business practices based upon a principle of security by design and industry best practices."
+        },
+        {
+          "ref": "DSP-08",
+          "label": "Data Privacy by Design and Default",
+          "description": "Develop systems, products, and business practices based upon a principle of privacy by design and industry best practices. Ensure that systems' privacy settings are configured by default, according to all applicable laws and regulations."
+        },
+        {
+          "ref": "DSP-09",
+          "label": "Data Protection Impact Assessment",
+          "description": "Conduct a Data Protection Impact Assessment (DPIA) to evaluate the origin, nature, particularity and severity of the risks upon the processing of personal data, according to any applicable laws, regulations and industry best practices."
+        },
+        {
+          "ref": "DSP-10",
+          "label": "Sensitive Data Transfer",
+          "description": "Define, implement and evaluate processes, procedures and technical measures that ensure any transfer of personal or sensitive data is protected from unauthorized access and only processed within scope as permitted by the respective laws and regulations."
+        },
+        {
+          "ref": "DSP-11",
+          "label": "Personal Data Access, Reversal, Rectification and Deletion",
+          "description": "Define and implement, processes, procedures and technical measures to enable data subjects to request access to, modification, or deletion of their personal data, according to any applicable laws and regulations."
+        },
+        {
+          "ref": "DSP-12",
+          "label": "Limitation of Purpose in Personal Data Processing",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to ensure that personal data is processed according to any applicable laws and regulations and for the purposes declared to the data subject."
+        },
+        {
+          "ref": "DSP-13",
+          "label": "Personal Data Sub-processing",
+          "description": "Define, implement and evaluate processes, procedures and technical measures for the transfer and sub-processing of personal data within the service supply chain, according to any applicable laws and regulations."
+        },
+        {
+          "ref": "DSP-14",
+          "label": "Disclosure of Data Sub-processors",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to disclose the details of any personal or sensitive data access by sub-processors to the data owner prior to initiation of that processing."
+        },
+        {
+          "ref": "DSP-15",
+          "label": "Limitation of Production Data Use",
+          "description": "Obtain authorization from data owners, and manage associated risk before replicating or using production data in non-production environments."
+        },
+        {
+          "ref": "DSP-16",
+          "label": "Data Retention and Deletion",
+          "description": "Data retention, archiving and deletion is managed in accordance with business requirements, applicable laws and regulations."
+        },
+        {
+          "ref": "DSP-17",
+          "label": "Sensitive Data Protection",
+          "description": "Define and implement, processes, procedures and technical measures to protect sensitive data throughout it's lifecycle."
+        },
+        {
+          "ref": "DSP-18",
+          "label": "Disclosure Notification",
+          "description": "The service provider must implement and describe to service customers the procedure to manage and respond to requests for disclosure of Personal Data by Law Enforcement Authorities according to applicable laws and regulations"
+        },
+        {
+          "ref": "DSP-19",
+          "label": "Data Location",
+          "description": "Define and implement, processes, procedures and technical measures to specify and document the physical locations of data, including any locations in which data is processed or backed up."
+        }
+      ]
+    },
+    {
+      "ref": "GRC",
+      "label": "Governance, Risk and Compliance",
+      "group": true,
+      "controls": [
+        {
+          "ref": "GRC-01",
+          "label": "Governance Program Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for an information governance program, which is sponsored by the leadership of the organization. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "GRC-02",
+          "label": "Risk Management Program",
+          "description": "Establish and maintain a formal, documented, and leadership-sponsored Enterprise Risk Management (ERM) program that includes policies and procedures for identification, evaluation, ownership, treatment, and acceptance of risks."
+        },
+        {
+          "ref": "GRC-03",
+          "label": "Organizational Policy Reviews",
+          "description": "Review all relevant organizational policies and associated procedures at least annually or when a substantial change occurs within the organization."
+        },
+        {
+          "ref": "GRC-04",
+          "label": "Policy Exception Process",
+          "description": "Establish and follow an approved exception process as mandated by the governance program whenever a deviation from an established policy occurs."
+        },
+        {
+          "ref": "GRC-05",
+          "label": "Information Security Program",
+          "description": "Develop and implement an Information Security Program, which includes programs for all the relevant domains of the CCM."
+        },
+        {
+          "ref": "GRC-06",
+          "label": "Governance Responsibility Model",
+          "description": "Define and document roles and responsibilities for planning, implementing, operating, assessing, and improving governance programs."
+        },
+        {
+          "ref": "GRC-07",
+          "label": "Information System Regulatory Mapping",
+          "description": "Identify and document all relevant standards, regulations, legal/contractual, and statutory requirements, which are applicable to your organization. Review at least annually or upon significant changes."
+        },
+        {
+          "ref": "GRC-08",
+          "label": "Special Interest Groups",
+          "description": "Establish and maintain contact with cloud-related special interest groups and other relevant entities in line with business context."
+        }
+      ]
+    },
+    {
+      "ref": "HRS",
+      "label": "Human Resources",
+      "group": true,
+      "controls": [
+        {
+          "ref": "HRS-01",
+          "label": "Background Screening Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for background verification of all new employees (including but not limited to remote employees, contractors, and third parties) according to local laws, regulations, ethics, and contractual constraints and proportional to the data classification to be accessed, the business requirements, and acceptable risk. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "HRS-02",
+          "label": "Acceptable Use of Technology Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for defining allowances and conditions for the acceptable use of organizationally-owned or managed assets. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "HRS-03",
+          "label": "Clean Desk Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures that require unattended workspaces to not have openly visible confidential data. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "HRS-04",
+          "label": "Remote and Home Working Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures to protect information accessed, processed or stored at remote sites and locations. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "HRS-05",
+          "label": "Asset returns",
+          "description": "Establish and document procedures for the return of organization-owned assets by terminated employees, contractors and third parties."
+        },
+        {
+          "ref": "HRS-06",
+          "label": "Employment Termination",
+          "description": "Establish, document, and communicate to all relevant personnel the procedures outlining the roles and responsibilities concerning changes in employment."
+        },
+        {
+          "ref": "HRS-07",
+          "label": "Employment Agreement Process",
+          "description": "Employees sign the employee agreement prior to being granted access to organizational information systems, resources and assets."
+        },
+        {
+          "ref": "HRS-08",
+          "label": "Employment Agreement Content",
+          "description": "The organization includes within the employment agreements provisions and/or terms for adherence to established information governance and security policies."
+        },
+        {
+          "ref": "HRS-09",
+          "label": "Personnel Roles and Responsibilities",
+          "description": "Establish, document and communicate roles and responsibilities of employees, as they relate to information assets' security and privacy."
+        },
+        {
+          "ref": "HRS-10",
+          "label": "Non-Disclosure Agreements",
+          "description": "Identify, document, and review, at planned intervals, requirements for non-disclosure/confidentiality agreements reflecting the organization's needs for the protection of data and operational details."
+        },
+        {
+          "ref": "HRS-11",
+          "label": "Security Awareness Training",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain a security awareness training program for all employees of the organization and provide regular training updates."
+        },
+        {
+          "ref": "HRS-12",
+          "label": "Personal and Sensitive Data Awareness and Training",
+          "description": "Provide employees with access to sensitive organizational and personal data with appropriate security awareness training and regular updates in organizational procedures, processes, and policies relating to their professional function relative to the organization."
+        },
+        {
+          "ref": "HRS-13",
+          "label": "Compliance User Responsibility",
+          "description": "Make employees aware of their roles and responsibilities for maintaining awareness and compliance with established policies and procedures and applicable legal, statutory, or regulatory compliance obligations."
+        }
+      ]
+    },
+    {
+      "ref": "IAM",
+      "label": "Identity & Access Management",
+      "group": true,
+      "controls": [
+        {
+          "ref": "IAM-01",
+          "label": "Identity and Access Management Policy and Procedures",
+          "description": "Establish, document, approve, communicate, implement, apply, evaluate, and maintain policies and procedures for identity and access management. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "IAM-02",
+          "label": "Credentials Management Policy and Procedures",
+          "description": "Establish, document, approve, communicate, implement, apply, evaluate, and maintain policies and procedures for the management of authentication credentials, including passwords. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "IAM-03",
+          "label": "Identity Inventory",
+          "description": "Manage, store, and regularly review the inventory of identities, and monitor their level of access."
+        },
+        {
+          "ref": "IAM-04",
+          "label": "Separation of Duties",
+          "description": "Employ the separation of duties principle when implementing information system access."
+        },
+        {
+          "ref": "IAM-05",
+          "label": "Least Privilege",
+          "description": "Employ the least privilege principle when implementing information system access."
+        },
+        {
+          "ref": "IAM-06",
+          "label": "Access Provisioning",
+          "description": "Define and implement an identity access provisioning process which authorizes, records, and communicates access changes to data and assets."
+        },
+        {
+          "ref": "IAM-07",
+          "label": "Access Changes and Revocation",
+          "description": "De-provision or modify identity access in a timely manner."
+        },
+        {
+          "ref": "IAM-08",
+          "label": "Access Review",
+          "description": "Review and revalidate identity access for least privilege and separation of duties with a frequency that is commensurate with organizational risk tolerance, and at least annually or upon significant changes."
+        },
+        {
+          "ref": "IAM-09",
+          "label": "Segregation of Privileged Access Roles",
+          "description": "Define, implement and evaluate processes, procedures and technical measures for the segregation of privileged access roles."
+        },
+        {
+          "ref": "IAM-10",
+          "label": "Management of Privileged Access Roles",
+          "description": "Define and implement an access process to ensure privileged access roles and rights are granted for a time limited period, and implement procedures to prevent the accumulation of segregated privileged access."
+        },
+        {
+          "ref": "IAM-11",
+          "label": "Service Customers Approval for Agreed Privileged Access Roles",
+          "description": "Define, implement and evaluate processes and procedures for service customers to participate, where applicable, in the granting of access for agreed, high risk (as defined by the organizational risk assessment) privileged access roles."
+        },
+        {
+          "ref": "IAM-12",
+          "label": "Unique Identities",
+          "description": "Define, implement and evaluate processes, procedures and technical measures that ensure identities’ activities are identifiable through uniquely associated IDs."
+        },
+        {
+          "ref": "IAM-13",
+          "label": "Strong Authentication",
+          "description": "Define, implement and evaluate processes, procedures and technical measures for authenticating access to systems, application and data assets, including multifactor authentication for at least privileged user and sensitive data access. Adopt digital certificates or alternatives which achieve an equivalent level of security for system identities."
+        },
+        {
+          "ref": "IAM-14",
+          "label": "Credentials Management",
+          "description": "Define, implement and evaluate processes, procedures and technical measures for the secure management of authentication credentials, including passwords."
+        },
+        {
+          "ref": "IAM-15",
+          "label": "Authorization Mechanisms",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to verify access to data and system functions is authorized."
+        }
+      ]
+    },
+    {
+      "ref": "IPY",
+      "label": "Interoperability & Portability",
+      "group": true,
+      "controls": [
+        {
+          "ref": "IPY-01",
+          "label": "Interoperability and Portability Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for interoperability and portability including requirements for: a. Communications between application interfaces b. Information processing interoperability c. Application development portability d. Information/Data exchange, usage, portability, integrity, and persistence Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "IPY-02",
+          "label": "Application Interface Availability",
+          "description": "Provide application interface(s) to service customers so that they programmatically retrieve their data to enable interoperability and portability."
+        },
+        {
+          "ref": "IPY-03",
+          "label": "Secure Interoperability and Portability Management",
+          "description": "Implement cryptographically secure network protocols for the management, import and export of data, according to industry standards."
+        },
+        {
+          "ref": "IPY-04",
+          "label": "Data Portability Contractual Obligations",
+          "description": "Agreements must include provisions specifying service customers' access to data upon contract termination and will include: a. Data format b. Length of time the data will be stored c. Scope of the data retained and made available to the service customers d. Data deletion policy"
+        }
+      ]
+    },
+    {
+      "ref": "I&S",
+      "label": "Infrastructure Security",
+      "group": true,
+      "controls": [
+        {
+          "ref": "I&S-01",
+          "label": "Infrastructure and Virtualization Security Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for infrastructure and virtualization security. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "I&S-02",
+          "label": "Capacity and Resource Planning",
+          "description": "Plan and monitor the availability, quality, and adequate capacity of resources in order to deliver the required system performance as determined by the business."
+        },
+        {
+          "ref": "I&S-03",
+          "label": "Network Security",
+          "description": "Monitor, encrypt and restrict communications between environments, services, and applications to only authenticated and authorized connections, as justified by the business. Review these configurations at least annually, and support them by a documented justification of all allowed services, protocols, ports, and compensating controls."
+        },
+        {
+          "ref": "I&S-04",
+          "label": "OS Hardening and Base Controls",
+          "description": "Harden host and guest OS, hypervisor or infrastructure control plane according to their respective best practices, and supported by technical controls, as part of a security baseline."
+        },
+        {
+          "ref": "I&S-05",
+          "label": "Production and Non-Production Environments",
+          "description": "Separate production and non-production environments to reduce the risk of sensitive production data being used in non-production environments. Production data is sanitized or protected before any authorized non-production use."
+        },
+        {
+          "ref": "I&S-06",
+          "label": "Segmentation and Segregation",
+          "description": "Design, develop, deploy and configure applications and infrastructures such that service customer (tenant) access is appropriately segmented and segregated, monitored and restricted."
+        },
+        {
+          "ref": "I&S-07",
+          "label": "Migration to Cloud Environments",
+          "description": "Use secure and encrypted communication channels when migrating servers, services, applications, or data to cloud environments. Such channels must include only up-to-date and approved protocols."
+        },
+        {
+          "ref": "I&S-08",
+          "label": "Network Architecture Documentation",
+          "description": "Identify and document high-risk environments based on data sensitivity, threat exposure, and business impact."
+        },
+        {
+          "ref": "I&S-09",
+          "label": "Network Defense",
+          "description": "Define, implement and evaluate processes, procedures and defense-in-depth techniques for protection, detection, and timely response to network-based attacks."
+        }
+      ]
+    },
+    {
+      "ref": "LOG",
+      "label": "Logging and Monitoring",
+      "group": true,
+      "controls": [
+        {
+          "ref": "LOG-01",
+          "label": "Logging and Monitoring Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for logging and monitoring. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "LOG-02",
+          "label": "Audit Logs Protection",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to ensure the security and retention of audit logs."
+        },
+        {
+          "ref": "LOG-03",
+          "label": "Security Monitoring and Alerting",
+          "description": "Identify and monitor security-related events within applications and the underlying infrastructure. Define and implement a system to generate alerts to responsible stakeholders based on such events and corresponding metrics."
+        },
+        {
+          "ref": "LOG-04",
+          "label": "Audit Logs Access and Accountability",
+          "description": "Restrict audit log access to authorized identities and maintain records of that access."
+        },
+        {
+          "ref": "LOG-05",
+          "label": "Audit Logs Monitoring and Response",
+          "description": "Implement and maintain capabilities to correlate and monitor security audit logs for the detection of suspicious or anomalous activity that deviates from typical or expected patterns. Establish and follow a defined process to review and take appropriate and timely actions on detected anomalies."
+        },
+        {
+          "ref": "LOG-06",
+          "label": "Clock Synchronization",
+          "description": "Use a reliable time source across all relevant information processing systems."
+        },
+        {
+          "ref": "LOG-07",
+          "label": "Logging Scope",
+          "description": "Establish, document and implement which information meta/data system events should be logged. Review and update the scope at least annually or whenever there is a change in the threat environment, and as per relevant regulatory requirements."
+        },
+        {
+          "ref": "LOG-08",
+          "label": "Audit Logs Sanitization",
+          "description": "Define, implement and evaluate technical measures for service customers to detect and scrub or tokenize sensitive data from logs to prevent unauthorized exposure, as per applicable laws and regulations."
+        },
+        {
+          "ref": "LOG-09",
+          "label": "Log Records",
+          "description": "Generate audit records containing relevant security information."
+        },
+        {
+          "ref": "LOG-10",
+          "label": "Audit Records Protection",
+          "description": "Protect audit records from unauthorized access, modification, and deletion."
+        },
+        {
+          "ref": "LOG-11",
+          "label": "Encryption Monitoring and Reporting",
+          "description": "Establish and maintain a monitoring and internal reporting capability over the operations of cryptographic, encryption and key management policies, processes, procedures, and controls."
+        },
+        {
+          "ref": "LOG-12",
+          "label": "Transaction/Activity Logging",
+          "description": "Log and monitor key lifecycle management events to enable auditing and reporting on usage of cryptographic keys."
+        },
+        {
+          "ref": "LOG-13",
+          "label": "Access Control Logs",
+          "description": "Monitor and log physical access using an auditable access control system."
+        },
+        {
+          "ref": "LOG-14",
+          "label": "Failures and Anomalies Reporting",
+          "description": "Define, implement and evaluate processes, procedures and technical measures for the reporting of anomalies and failures of the monitoring system and provide immediate notification to the accountable party."
+        }
+      ]
+    },
+    {
+      "ref": "SEF",
+      "label": "Security Incident Management, E-Discovery, & Cloud Forensics",
+      "group": true,
+      "controls": [
+        {
+          "ref": "SEF-01",
+          "label": "Security Incident Management Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for Security Incident Management, E-Discovery, and Cloud Forensics. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "SEF-02",
+          "label": "Service Management Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for the timely management of security incidents. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "SEF-03",
+          "label": "Incident Response Plans",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain a security incident response plan, which includes but is not limited to: a communication strategy for notifying relevant internal departments, impacted service customers, and other business critical relationships (such as supply-chain) that may be impacted."
+        },
+        {
+          "ref": "SEF-04",
+          "label": "Incident Response Testing",
+          "description": "Exercise the incident response plans at planned intervals or upon significant changes."
+        },
+        {
+          "ref": "SEF-05",
+          "label": "Incident Response Metrics",
+          "description": "Establish, monitor and report information security incident metrics."
+        },
+        {
+          "ref": "SEF-06",
+          "label": "Event Triage Processes",
+          "description": "Define, implement and evaluate processes, procedures and technical measures supporting business processes to triage security-related events."
+        },
+        {
+          "ref": "SEF-07",
+          "label": "Incident Management and Response",
+          "description": "Define, implement and evaluate processes, procedures and technical measures for timely and effective response to security incidents in accordance with incident categories and severity levels. Review, update, and test processes and procedures at least annually."
+        },
+        {
+          "ref": "SEF-08",
+          "label": "Security Breach Notification",
+          "description": "Define and implement processes, procedures and technical measures for security breach notifications. Report material security breaches including any relevant supply chain breaches, as per applicable SLAs, laws and regulations."
+        },
+        {
+          "ref": "SEF-09",
+          "label": "Incident Records Management",
+          "description": "Establish and maintain a secure repository of security incident records. Regularly review the incident records to identify patterns, root causes, and systemic vulnerabilities, and implement relevant corrective measures."
+        },
+        {
+          "ref": "SEF-10",
+          "label": "Points of Contact Maintenance",
+          "description": "Maintain points of contact for applicable regulation authorities, national and local law enforcement, and other legal jurisdictional authorities. Review and update the points of contact at least annually."
+        }
+      ]
+    },
+    {
+      "ref": "STA",
+      "label": "Supply Chain Management, Transparency, and Accountability",
+      "group": true,
+      "controls": [
+        {
+          "ref": "STA-01",
+          "label": "Supply Chain Risk Management Policies and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate, and maintain policies and procedures for supply chain risk management. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "STA-02",
+          "label": "SSRM Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for the application of the Shared Security Responsibility Model (SSRM) within the organization. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "STA-03",
+          "label": "SSRM Supply Chain",
+          "description": "Apply, document, implement and manage the SSRM throughout the supply chain."
+        },
+        {
+          "ref": "STA-04",
+          "label": "SSRM Guidance",
+          "description": "Provide SSRM Guidance to the service customers detailing information about the SSRM applicability throughout the supply chain."
+        },
+        {
+          "ref": "STA-05",
+          "label": "SSRM Control Ownership",
+          "description": "Delineate the shared ownership and applicability of all CSA CCM controls according to the SSRM."
+        },
+        {
+          "ref": "STA-06",
+          "label": "SSRM Documentation Review",
+          "description": "Review and validate the SSRM documentation."
+        },
+        {
+          "ref": "STA-07",
+          "label": "SSRM Control Implementation",
+          "description": "Implement, operate, and audit or assess the portions of the SSRM which the organization is responsible for."
+        },
+        {
+          "ref": "STA-08",
+          "label": "Supply Chain Inventory",
+          "description": "Develop and maintain an inventory of all supply chain relationships."
+        },
+        {
+          "ref": "STA-09",
+          "label": "Service Bill of Material (BOM)",
+          "description": "Define, implement, and enforce a process for establishing a Bill of Material for the service supply chain. Review and update the Bill of Material at least annually or upon significant changes."
+        },
+        {
+          "ref": "STA-10",
+          "label": "Supply Chain Risk Management",
+          "description": "Periodically review risk factors associated with supply chain relationships."
+        },
+        {
+          "ref": "STA-11",
+          "label": "Primary Service and Contractual Agreement",
+          "description": "Service agreements must incorporate at least the following mutually-agreed upon provisions and/or terms: • Scope, characteristics and location of business relationship and services offered • Information security requirements (including SSRM) • Change management process • Logging and monitoring capability • Incident management and communication procedures • Right to audit and third party assessment • Service termination • Interoperability and portability requirements • Data privacy • Operational Resilience"
+        },
+        {
+          "ref": "STA-12",
+          "label": "Supply Chain Agreement Review",
+          "description": "Review supply chain agreements at least annually or upon significant changes."
+        },
+        {
+          "ref": "STA-13",
+          "label": "Supply Chain Compliance Assessment",
+          "description": "Define and implement a process for conducting internal assessments to confirm conformance and effectiveness of standards, policies, procedures, and service level agreement activities at least annually."
+        },
+        {
+          "ref": "STA-14",
+          "label": "Supply Chain Service Agreement Compliance",
+          "description": "Implement policies requiring all service providers throughout the supply chain to comply with information security, confidentiality, access control, privacy, audit, personnel policy and service level requirements and standards."
+        },
+        {
+          "ref": "STA-15",
+          "label": "Supply Chain Governance Review",
+          "description": "Review the organization's service providers' IT governance policies and procedures at least annually or upon significant changes."
+        },
+        {
+          "ref": "STA-16",
+          "label": "Supply Chain Data Security Assessment",
+          "description": "Define and implement a process for conducting risk-based security assessments of the supply chain."
+        }
+      ]
+    },
+    {
+      "ref": "TVM",
+      "label": "Threat & Vulnerability Management",
+      "group": true,
+      "controls": [
+        {
+          "ref": "TVM-01",
+          "label": "Threat and Vulnerability Management Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures to identify, report and prioritize the remediation of vulnerabilities and threats, in order to protect systems against vulnerability exploitation. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "TVM-02",
+          "label": "Malware and Malicious Instructions Protection Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures to protect against malware and malicious instructions. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "TVM-03",
+          "label": "Vulnerability Identification",
+          "description": "Define, implement and evaluate processes, procedures and technical measures for the detection of vulnerabilities on organizationally managed assets at least monthly."
+        },
+        {
+          "ref": "TVM-04",
+          "label": "Threat Analysis and Modelling",
+          "description": "Define, implement, and evaluate a threat analysis process and procedures to identify, assess and review the threat landscape for cloud systems. Build threat models according to industry best practices to inform the risk mitigation strategy."
+        },
+        {
+          "ref": "TVM-05",
+          "label": "Detection Updates",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to update detection tools, threat signatures, and indicators of compromise on a weekly, or more frequent basis."
+        },
+        {
+          "ref": "TVM-06",
+          "label": "External Library Vulnerabilities",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to identify updates for applications which use third party or open source libraries according to the organization's vulnerability management policy."
+        },
+        {
+          "ref": "TVM-07",
+          "label": "Penetration Testing",
+          "description": "Define, implement and evaluate processes, procedures and technical measures for the periodic performance of penetration testing by independent third parties."
+        },
+        {
+          "ref": "TVM-08",
+          "label": "Vulnerability Remediation Schedule",
+          "description": "Define, implement and evaluate processes, procedures and technical measures based on identified risks to support scheduled and emergency responses to vulnerability identification."
+        },
+        {
+          "ref": "TVM-09",
+          "label": "Vulnerability Prioritization",
+          "description": "Use a risk-based method for effective prioritization of vulnerability remediation using an industry recognized framework."
+        },
+        {
+          "ref": "TVM-10",
+          "label": "Threat Response",
+          "description": "Use a risk-based method for the prioritization and mitigation of threats, leveraging an industry-recognized framework to guide threat decision-making and protection measures."
+        },
+        {
+          "ref": "TVM-11",
+          "label": "Vulnerability Management Reporting",
+          "description": "Define and implement a process for tracking and reporting vulnerability identification and remediation activities that includes stakeholder notification."
+        },
+        {
+          "ref": "TVM-12",
+          "label": "Vulnerability Management Metrics",
+          "description": "Establish, monitor and report metrics for vulnerability identification and remediation at defined intervals."
+        }
+      ]
+    },
+    {
+      "ref": "UEM",
+      "label": "Universal Endpoint Management",
+      "group": true,
+      "controls": [
+        {
+          "ref": "UEM-01",
+          "label": "Endpoint Devices Policy and Procedures",
+          "description": "Establish, document, approve, communicate, apply, evaluate and maintain policies and procedures for all endpoints. Review and update the policies and procedures at least annually, or upon significant changes."
+        },
+        {
+          "ref": "UEM-02",
+          "label": "Application and Service Approval",
+          "description": "Define, document, apply and evaluate a list of approved services, applications and sources of applications (stores) acceptable for use by endpoints when accessing or storing organization-managed data."
+        },
+        {
+          "ref": "UEM-03",
+          "label": "Compatibility",
+          "description": "Define and implement a process for the validation of the endpoint device's compatibility with operating systems and applications."
+        },
+        {
+          "ref": "UEM-04",
+          "label": "Endpoint Inventory",
+          "description": "Maintain an inventory of all endpoints used to store, access and process company data."
+        },
+        {
+          "ref": "UEM-05",
+          "label": "Endpoint Management",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to enforce policies and controls for all endpoints permitted to access systems and/or store, transmit, or process organizational data."
+        },
+        {
+          "ref": "UEM-06",
+          "label": "Automatic Lock Screen",
+          "description": "Configure all relevant interactive-use endpoints to require an automatic lock screen."
+        },
+        {
+          "ref": "UEM-07",
+          "label": "Operating Systems",
+          "description": "Manage changes to endpoint operating systems, patch levels, and/or applications through the company's change management processes."
+        },
+        {
+          "ref": "UEM-08",
+          "label": "Storage Encryption",
+          "description": "Protect information from unauthorized disclosure on managed endpoint devices with storage encryption."
+        },
+        {
+          "ref": "UEM-09",
+          "label": "Anti-Malware Detection and Prevention",
+          "description": "Configure managed endpoints with anti-malware detection and prevention technology and services."
+        },
+        {
+          "ref": "UEM-10",
+          "label": "Software Firewall",
+          "description": "Configure managed endpoints with properly configured software firewalls."
+        },
+        {
+          "ref": "UEM-11",
+          "label": "Data Loss Prevention",
+          "description": "Configure managed endpoints with Data Loss Prevention (DLP) technologies and rules in accordance with a risk assessment."
+        },
+        {
+          "ref": "UEM-12",
+          "label": "Remote Locate",
+          "description": "Enable remote geo-location capabilities for all managed mobile endpoints, according to all applicable laws and regulations."
+        },
+        {
+          "ref": "UEM-13",
+          "label": "Remote Wipe",
+          "description": "Define, implement and evaluate processes, procedures and technical measures to enable the deletion of company data remotely on managed endpoint devices."
+        },
+        {
+          "ref": "UEM-14",
+          "label": "Third-Party Endpoint Security Posture",
+          "description": "Define, implement and evaluate processes, procedures and technical and/or contractual measures to maintain proper security of third-party endpoints with access to organizational assets."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **CSA Cloud Controls Matrix (CCM) v4.1.0** as a built-in framework, authored from the official CCM+CAIQ v4.1 workbook.

- **17 domains** as `group:true` nodes, **207 control objectives** as leaves (`label` = control title, `description` = control specification, normalized to single-paragraph plain text).
- `scf_keys: ["csa-ccm-4-1-0"]` aliases onto the CCM that SCF already carries, so it unifies with the SCF crosswalk instead of duplicating.

Note: v4.1.0 renamed Infrastructure & Virtualization Security (IVS) → Infrastructure Security (`I&S`) and expanded several domains, hence **207** controls (vs 197 in v4.0.x). Refs match the source workbook exactly.

## Validation

`bun run frameworks:check` (JSON lint + schema) passes. Loaded end-to-end through eload into a local catalog: 207 controls + 17 group domains, 0 markdown artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)