### PR TITLE
feat: add subset_code to profiles (membership label)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,16 +5,19 @@
     "": {
       "name": "episki-frameworks",
       "dependencies": {
+        "episki-frameworks": "github:episki/frameworks#5ad20ca15f0b2227c27a80c093cee122e55228d3",
         "securecontrolsframework": "securecontrolsframework/securecontrolsframework",
       },
       "devDependencies": {
-        "ajv": "latest",
-        "jsonc-parser": "latest",
+        "ajv": "^8.17.1",
+        "jsonc-parser": "^3.3.1",
       },
     },
   },
   "packages": {
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "episki-frameworks": ["episki-frameworks@github:episki/frameworks#5ad20ca", { "dependencies": { "securecontrolsframework": "securecontrolsframework/securecontrolsframework" } }, "episki-frameworks-5ad20ca", "sha512-qAM8wQV5wD45pTjxFM3HBeDMjsNvMkTDQjuCNCtUhnrVvDOmq6pCV7dUaXjBpNhA3D1a2dW2QQG3SWew0XJwSA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -27,5 +30,7 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "securecontrolsframework": ["securecontrolsframework@github:securecontrolsframework/securecontrolsframework#9b87762", {}, "securecontrolsframework-securecontrolsframework-9b87762"],
+
+    "episki-frameworks/securecontrolsframework": ["securecontrolsframework@github:securecontrolsframework/securecontrolsframework#e85e4c4", {}, "securecontrolsframework-securecontrolsframework-e85e4c4", "sha512-gqfqrFYSdXNQu/ts2q7YISHs1iWbBQPd1u+w+ESadMrVJXpNBlzUZ8MBwqHyUtLykqAzBw+4yAIkfigsLaEP0w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "jsonc-parser": "^3.3.1"
   },
   "dependencies": {
+    "episki-frameworks": "github:episki/frameworks#5ad20ca15f0b2227c27a80c093cee122e55228d3",
     "securecontrolsframework": "securecontrolsframework/securecontrolsframework"
   }
 }

--- a/profile.schema.json
+++ b/profile.schema.json
@@ -42,6 +42,11 @@
       "type": "string",
       "minLength": 1
     },
+    "subset_code": {
+      "description": "Short, stable membership label for this selection, e.g. 'A-EP' or 'lite'. This is the token a loader records against each included control (catalog.controls.subsets) and that consumers filter on. Distinct from `key`, which is the slug identifier.",
+      "type": "string",
+      "minLength": 1
+    },
     "keywords": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 },

--- a/profiles/csa-ccm-4-1-lite.json
+++ b/profiles/csa-ccm-4-1-lite.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "The \"CCM Lite\" subset of CSA Cloud Controls Matrix v4.1 (96 controls).",
   "category": "subset",
+  "subset_code": "lite",
   "imports": [
     {
       "catalog": "csa-ccm-4-1",

--- a/profiles/pci-saq-a-ep.json
+++ b/profiles/pci-saq-a-ep.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire A-EP subset of PCI DSS v4.0.1 (183 requirements).",
   "category": "saq",
+  "subset_code": "A-EP",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-a.json
+++ b/profiles/pci-saq-a.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire A subset of PCI DSS v4.0.1 (37 requirements).",
   "category": "saq",
+  "subset_code": "A",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-b-ip.json
+++ b/profiles/pci-saq-b-ip.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire B-IP subset of PCI DSS v4.0.1 (76 requirements).",
   "category": "saq",
+  "subset_code": "B-IP",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-b.json
+++ b/profiles/pci-saq-b.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire B subset of PCI DSS v4.0.1 (38 requirements).",
   "category": "saq",
+  "subset_code": "B",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-c-vt.json
+++ b/profiles/pci-saq-c-vt.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire C-VT subset of PCI DSS v4.0.1 (79 requirements).",
   "category": "saq",
+  "subset_code": "C-VT",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-c.json
+++ b/profiles/pci-saq-c.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire C subset of PCI DSS v4.0.1 (163 requirements).",
   "category": "saq",
+  "subset_code": "C",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-d-merchant.json
+++ b/profiles/pci-saq-d-merchant.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire D-Merchant subset of PCI DSS v4.0.1 (317 requirements).",
   "category": "saq",
+  "subset_code": "D-Merchant",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-d-sp.json
+++ b/profiles/pci-saq-d-sp.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire D-SP subset of PCI DSS v4.0.1 (326 requirements).",
   "category": "saq",
+  "subset_code": "D-SP",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-p2pe.json
+++ b/profiles/pci-saq-p2pe.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire P2PE subset of PCI DSS v4.0.1 (32 requirements).",
   "category": "saq",
+  "subset_code": "P2PE",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",

--- a/profiles/pci-saq-spoc.json
+++ b/profiles/pci-saq-spoc.json
@@ -6,6 +6,7 @@
   "last_updated": "2026-06-27",
   "description": "Self-Assessment Questionnaire SPoC subset of PCI DSS v4.0.1 (34 requirements).",
   "category": "saq",
+  "subset_code": "SPoC",
   "imports": [
     {
       "catalog": "pci-dss-4-0-1",


### PR DESCRIPTION
Follow-up to #15. Profiles now declare **`subset_code`** — the short, stable membership token (`A-EP`, `lite`, `P2PE`, `SPoC`, …) that a loader records against each included control (`catalog.controls.subsets`) and that consumers filter on. Distinct from the slug `key`.

Adds the optional field to `profile.schema.json` and populates it on all 11 PCI SAQ / CCM-lite profiles. This lets eload's `load-profiles` reproduce the exact membership labels the app expects without parsing the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)