### PR TITLE
fix: add SCF 2026.2 scf_keys aliases

### DIFF
--- a/frameworks/emea-eu-gdpr.json
+++ b/frameworks/emea-eu-gdpr.json
@@ -5,7 +5,8 @@
   "publisher": "European Union",
   "source_url": "https://eur-lex.europa.eu/eli/reg/2016/679/oj",
   "scf_keys": [
-    "emea-eu-gdpr"
+    "emea-eu-gdpr",
+    "emea-eu-gdpr-2016"
   ],
   "last_updated": "2025-07-18",
   "description": "European Union regulation on data protection and privacy for individuals within the EU and EEA.",

--- a/frameworks/emea-uk-cyber-essentials.json
+++ b/frameworks/emea-uk-cyber-essentials.json
@@ -6,7 +6,8 @@
   "publisher": "UK National Cyber Security Centre",
   "source_url": "https://www.ncsc.gov.uk/cyberessentials/",
   "scf_keys": [
-    "emea-uk-cyber-essentials"
+    "emea-uk-cyber-essentials",
+    "emea-uk-cyber-essentials-3-3"
   ],
   "last_updated": "2025-04-01",
   "description": "UK government-backed certification scheme for protecting against common cyber threats through basic security controls.",


### PR DESCRIPTION
SCF 2026.2 renamed its GDPR and UK Cyber Essentials focal-document columns (`emea-eu-gdpr` → `emea-eu-gdpr-2016`, `emea-uk-cyber-essentials` → `emea-uk-cyber-essentials-3-3`). Adds the new keys alongside the old ones so eload's load-scf aliases both SCF versions onto the existing episki frameworks instead of creating duplicate rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)